### PR TITLE
add beacon to support site

### DIFF
--- a/overrides/base.html
+++ b/overrides/base.html
@@ -61,6 +61,10 @@
     {% include 'analytics.html' %}
   {%- endblock %}
 
+  {%- block beacon %}
+    {% include 'beacon.html' %}
+  {%- endblock %}
+
   {%- block extrahead %} {% endblock %}
 </head>
 

--- a/overrides/beacon.html
+++ b/overrides/beacon.html
@@ -1,0 +1,33 @@
+<script type="text/javascript">!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});</script>
+<script type="text/javascript">
+  document.addEventListener("DOMContentLoaded", function() {
+    window.Beacon('config', {display: { style: 'icon' }});
+    window.Beacon('init', '2efd68d8-0479-42c1-a94c-87b342af7bc4');
+    fetch('https://api.getgrist.com/api/session/access/all', {credentials: 'include'})
+      .then(function(resp) { return resp.json(); })
+      .then(function(status) {
+        // If there's exactly two orgs, will use the team name for the non-merged personal
+        // org as the company name.  Otherwise don't worry about setting company name.
+        var org = undefined;
+        if (status.orgs.length === 2) {
+          org = status.orgs[0].owner ? status.orgs[1] : status.orgs[0];
+        }
+        // If there's one user account available, fill it in silently; otherwise use
+        // the first one and prefill fields but let user see them so they can override
+        // them.  If testing this, be aware that if 'identify' was called previously,
+        // it will be cached in local storage and used even if it is not set this time
+        // around.
+        var user = status.users[0];
+        var identifyOrPrefill = status.users.length === 1 ? 'identify' : 'prefill';
+        if (user && !user.anonymous) {
+          var userObj = {};
+          if (user.email) { userObj.email = user.email; }
+          if (user.name) { userObj.name = user.name; }
+          if (user.picture) { userObj.avatar = user.picture; }
+          if (user.helpScoutSignature) { userObj.signature = user.helpScoutSignature; }
+          if (org && org.name) { userObj.company = org.name; }
+          window.Beacon(identifyOrPrefill, userObj);
+        }
+      });
+  });
+</script>


### PR DESCRIPTION
This adds the helpscout beacon to the support site.
If a single user login is available on api.getgrist.com,
that identity is used.  If multiple logins are available,
one is prefilled arbitrarily, but not marked definitively
as the user's identity (so it will show in the contact form
rather than being hidden).  If one team site is available,
its name is used as the company name.