### PR TITLE
Add a bit of clarification around confusingly similar Clients vs Clients in the example.

### DIFF
--- a/help/col-refs.md
+++ b/help/col-refs.md
@@ -94,9 +94,9 @@ If you're comfortable using formulas, you can see that the added column is just 
 the formula column. You can also use any other fields from `Clients` table by referencing `$Client`
 in formulas in the `Projects` table.
 
-Note that we use the name of the reference *column* (`$Client`) to refer to a linked record in
-formulas, not the name of the table (which is `Clients` here). Don't let the similarity of the
-names in this example confuse you.
+Note that in formulas, we use the name of the reference *column* (`$Client`) to refer to a linked
+record, not the name of the table (which is `Clients` here). Don't let the similarity of the names
+in this example confuse you.
 
 *![Additional columns as formulas](images/column-ref-other-formula.png)*
 {: .screenshot-half }


### PR DESCRIPTION
See https://secure.helpscout.net/conversation/1134766797/197?folderId=3185973#thread-3225958791 

> ...you are using very similar names for your Table and Reference Field (Clients vs Clients). It implies that you call the Table.ReferenceFieldName and not Column.ReferenceFieldName. Very difficult when reading to see that Client is different than Clients. I would recommend fixing and use very different values, so it's easy to spot.

An alternative would be to start right away with actually different names (e.g. "Clients"/"Customer", or "Client List"/"Client"), but I couldn't convince myself these would be strictly better.