### PR TITLE
add a site_url to fix sitemap.xml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: Grist Help Center
 site_dir: site
 site_favicon: images/favicon.png
 site_description: "Tutorials and resources for Grist, to help you organize your data, your way."
+site_url: "https://support.getgrist.com"
 
 docs_dir: './help'
 # windmill is a theme maintained by Grist Labs in https://github.com/gristlabs/mkdocs-windmill


### PR DESCRIPTION
The site map at https://support.getgrist.com/sitemap.xml is currently
broken, this adds a `site_url` setting that should fix it
(confirmed on support-preview).