### PR TITLE
move example documents to public.getgrist.com

### DIFF
--- a/help/examples/2020-06-book-club.md
+++ b/help/examples/2020-06-book-club.md
@@ -105,5 +105,5 @@ Once we have all these links, it makes sense to add a [Card View](../linking-wid
 ## Ready-made template
 
 Here is an
-[example book list](https://docs.getgrist.com/2s1QBQyExxj2/Book-Club/m/fork){:target="\_blank"}
+[example book list](https://public.getgrist.com/hitjMGXBvPXP/Book-Club/m/fork){:target="\_blank"}
 that you can play with. The actual books listed may not be your thing, of course!  Adjust to taste.

--- a/help/examples/2020-06-credit-card.md
+++ b/help/examples/2020-06-credit-card.md
@@ -21,7 +21,7 @@ any transaction to see its complete details.
 ![By Category](/examples/images/2020-06-credit-card-by-category.png)
 
 Here is the
-[example with sample data](https://docs.getgrist.com/kmmB7wgUnfXx/AmEx-Activity-Example/m/fork){:target="\_blank"}
+[example with sample data](https://public.getgrist.com/1npTYpf2Cgyk/AmEx-Activity-Example/m/fork){:target="\_blank"}
  that you can play with.
 
 To use it for your own data, start by downloading your transactions. For American Express
@@ -35,7 +35,7 @@ credit cards:
 
 To import this data into Grist:
 
-1. Open the [template here](https://docs.getgrist.com/k1msFNNJKzqh/AmEx-Activity-Template/m/fork){:target="\_blank"}.
+1. Open the [template here](https://public.getgrist.com/mMbk6UEHoHYf/AmEx-Activity-Template/m/fork){:target="\_blank"}.
 2. Click "Add New" button and choose "Import from file".
 3. In the dialog that shows, change “To” table from “New Table” to “Activity”, like so:
 

--- a/help/examples/2020-07-email-compose.md
+++ b/help/examples/2020-07-email-compose.md
@@ -26,7 +26,7 @@ person:
 {: .screenshot-half }
 
 See an example of this in action here:
-[Simple Compose](https://docs.getgrist.com/8zmCtN4oXc6g/Email-Links/m/fork){:target="\_blank"}.
+[Simple Compose](https://public.getgrist.com/eZPYkB1W2Jcu/Email-Links/m/fork){:target="\_blank"}.
 
 ## Cc, Bcc, Subject, Body
 
@@ -53,7 +53,7 @@ return "Compose mailto:%s?cc=sales@example.com&subject=%s&body=%s" % (
 ```
 
 A live example of this is here:
-[Advanced Compose](https://docs.getgrist.com/8zmCtN4oXc6g/Email-Links/p/2/m/fork){:target="\_blank"}.
+[Advanced Compose](https://public.getgrist.com/eZPYkB1W2Jcu/Email-Links/p/2/m/fork){:target="\_blank"}.
 
 ## Emailing Multiple People
 
@@ -72,7 +72,7 @@ return "Email Group mailto:%s" % quote(", ".join(people.Email))
 ```
 
 You can see this formula at work in
-[Group Compose](https://docs.getgrist.com/8zmCtN4oXc6g/Email-Links/p/3/m/fork){:target="\_blank"}.
+[Group Compose](https://public.getgrist.com/eZPYkB1W2Jcu/Email-Links/p/3/m/fork){:target="\_blank"}.
 
 Don't use this to replace an email marketing platform: since emails use your regular
 email program, you shouldn't use it for emailing thousands of people. But for small groups, this

--- a/help/examples/2020-11-treasure-hunt.md
+++ b/help/examples/2020-11-treasure-hunt.md
@@ -16,7 +16,7 @@ Here's an example hunt:
 
 You can play with the example yourself here:
 
-> <https://docs.getgrist.com/au8zHA1QiBPU/Treasure-Hunt/m/fork>
+> <https://public.getgrist.com/2CdspaixULZa/Treasure-Hunt/m/fork>
 
 Once ready to start your own completely fresh hunt just do "Save Copy"
 and select "As Template".


### PR DESCRIPTION
This gathers up some documents from personal accounts and copies them to public.getgrist.com (with action history truncated when needed).