### PR TITLE
Add a link to Community in top bar, and to Function Reference under R…

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,9 @@ nav:
       - Time and User Stamps: examples/2021-07-auto-stamps.md
   - Reference:
     - Shortcuts: keyboard-shortcuts.md
+    # The function reference (functions.md) is listed above; here is an intentionally non-standard
+    # link, so that only the above page item gets highlighted when the function reference is open.
+    - Function reference: /functions/
     - Limits: limits.md
     - Browser Support: browser-support.md
     - Glossary: glossary.md
@@ -105,9 +108,11 @@ extra:
   version: '1.0.2-dev'
   article_nav_bottom: false
   history_buttons: false
-  home_link:
-    href: https://www.getgrist.com
-    text: 'Back to Grist'
+  home_links:
+    - href: https://community.getgrist.com
+      text: 'Community'
+    - href: https://www.getgrist.com
+      text: 'Back to Grist'
 extra_css:
   - css/grist.css
 extra_javascript:

--- a/overrides/topbar.html
+++ b/overrides/topbar.html
@@ -35,14 +35,14 @@
     </div>
     {% endif %}
 
-    {# CHANGED: Add link to product homepage, if extra.home_link.{href,text} property is present #}
-    {% if config.extra.home_link %}
-    <a href="{{ config.extra.home_link.href }}" class="wm-top-tool wm-top-link pull-right wm-vcenter home-link">
-      <div class="wm-top-title">
-        {{ config.extra.home_link.text }}
-      </div>
-    </a>
-    {% endif %}
+    {# CHANGED: Add links to topbar if have extra.home_links list with {href,text} properties #}
+    {% for link in config.extra.home_links %}
+      <a href="{{ link.href }}" class="wm-top-tool wm-top-link pull-right wm-vcenter home-link">
+        <div class="wm-top-title">
+          {{ link.text }}
+        </div>
+      </a>
+    {% endfor %}
 
     {# Logo and title #}
     <a href="{{ nav.homepage.url|url }}" class="wm-top-brand wm-top-link wm-vcenter">


### PR DESCRIPTION
…eference section.

The link to the Community mirrors a similar link to the Help Center on
the Community site.

The link to Function Reference is a second link in the navigation menu,
which is awkward (on clicking it, the other nav item will be
highlighted) but the Reference section is another natural place to look
for the function reference.

See https://support-preview.getgrist.com/