### PR TITLE
Enable link to repo to edit documentation on GitHub

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,8 @@ site_name: Grist Help Center
 site_dir: site
 site_description: "Tutorials and resources for Grist, to help you organize your data, your way."
 site_url: "https://support.getgrist.com"
+repo_name: "GitHub"
+repo_url: "https://github.com/gristlabs/grist-help"
 
 docs_dir: './help'
 # windmill is a theme maintained by Grist Labs in https://github.com/gristlabs/mkdocs-windmill

--- a/overrides/css/base.css
+++ b/overrides/css/base.css
@@ -147,10 +147,8 @@ body {
 }
 
 .wm-toc-repo {
-  margin-top: -15px;
-  margin-bottom: 5px;
-  padding-bottom: 5px;
-  border-bottom: 1px solid #e0e0e0;
+  padding-top: 10px;
+  border-top: 1px solid #e0e0e0;
 }
 
 .wm-toc-hidden > .wm-toc-pane {

--- a/overrides/css/base.css
+++ b/overrides/css/base.css
@@ -148,7 +148,6 @@ body {
 
 .wm-toc-repo {
   padding-top: 10px;
-  border-top: 1px solid #e0e0e0;
 }
 
 .wm-toc-hidden > .wm-toc-pane {

--- a/overrides/nav-pane.html
+++ b/overrides/nav-pane.html
@@ -1,19 +1,6 @@
 {# Side-pane with table of contents #}
 <nav class="wm-toc-pane">
   {# Optional link to the repository #}
-  {%- block repo %}
-    {%- if config.repo_url %}
-    <ul class="wm-toctree wm-toc-repo">
-      <li class="wm-toc-li wm-toc-lev1">
-      <a class="wm-article-link wm-toc-text" href="{{ config.repo_url }}">
-        {% include 'repo-icon.html' %}
-        {{ config.repo_name }}
-      </a>
-      </li>
-    </ul>
-    {%- endif %}
-  {%- endblock %}
-
   {%- block site_nav %}
   <ul class="wm-toctree">
     {%- set navlevel = 1 %}
@@ -36,6 +23,20 @@
         <a href="https://github.com/gristlabs/grist-core/projects/1" class="wm-quick-link wm-toc-text">Roadmap</a>
       </li>
     </ul>
+
+  {%- block repo %}
+    {%- if config.repo_url %}
+    <ul class="wm-toctree wm-toc-repo">
+      <li class="wm-toc-li wm-toc-lev2">
+      <a class="wm-quick-link wm-toc-text" href="{{ config.repo_url }}">
+        {% include 'repo-icon.html' %}
+        Edit on {{ config.repo_name }}
+      </a>
+      </li>
+    </ul>
+    {%- endif %}
+  {%- endblock %}
+
   </div>
 
 </nav>


### PR DESCRIPTION
Add a link below Quick Links to edit Help Center documentation. Preview: https://support-preview.getgrist.com/