### PR TITLE
Add workflow action to run 'publish.sh live' on every commit to master

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
 jobs:
-  push-to-helpscout:
+  publish-live:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -1,0 +1,21 @@
+name: Publish Live
+on:
+  push:
+    branches:
+      - master
+jobs:
+  push-to-helpscout:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Publish live
+        run: ./publish.sh live


### PR DESCRIPTION
This should cause docs to be automatically published once a PR is landed to master. On balance, it seems less error-prone than requiring it as a separate manual step.