### PR TITLE
Fix push_to_helpscout script, and fix some image links

### DIFF
--- a/help/linking-widgets.md
+++ b/help/linking-widgets.md
@@ -194,7 +194,7 @@ visualize](investment-research.md#dynamic-charts) tutorial.
 
 Lastly, tables that reference a summary table’s underlying data may now be linked to the summary table itself. In the image below, the Champion Dog's table has a [reference column](col-types.md#reference-columns) to the Breeder table. The Breeder table is being summarized in the top right widget by the "Country" column. Because Champion Dog references Breeder, you may add a widget of Champion Dogs that selects by a summary table of Breeder data.
 
-<span class="screenshot-large">*![Linking Referenced Data to Summary Table](../images/linking-summary-reference.gif)*</span>
+<span class="screenshot-large">*![Linking Referenced Data to Summary Table](images/linking-summary-reference.gif)*</span>
 
 ## Changing link settings
 

--- a/help/sharing.md
+++ b/help/sharing.md
@@ -92,7 +92,7 @@ Non-owners may look up their access details to a document by clicking on the sha
 (<span class="grist-icon" style="--icon: var(--icon-Share)"></span>) on top right of the
 screen and selecting "Access Details."
 
-![Access Details](../images/newsletters/2022-05/access-details.png)
+![Access Details](images/newsletters/2022-05/access-details.png)
 
 From the access details pop up, you may click the trash icon to leave a document.
 


### PR DESCRIPTION
The `push_to_helpscout.py` script used HelpScout's [find redirect](https://developer.helpscout.com/docs-api/redirects/find/) API, which surprisingly does not return an ID that could be used to update that redirect. This PR switches it to use [list redirects](https://developer.helpscout.com/docs-api/redirects/list/) API, which does include that ID.

This was causing failures in the automatic workflow [Push to HelpScout](https://github.com/gristlabs/grist-help/actions/workflows/push-to-helpscout.yml).