### PR TITLE
add missing help/code/enums directory for plugins documentation

### DIFF
--- a/build-plugin-api.sh
+++ b/build-plugin-api.sh
@@ -17,8 +17,9 @@ $DIR/node_modules/.bin/typedoc \
   --plugin "typedoc-plugin-markdown" \
   --hideBreadcrumbs \
   --logLevel Verbose
-rm -rf $DIR/help/code/interfaces $DIR/help/code/modules
+rm -rf $DIR/help/code/interfaces $DIR/help/code/modules $DIR/help/code/enums
 mv $DIR/tmp-code/interfaces $DIR/help/code/interfaces
 mv $DIR/tmp-code/modules $DIR/help/code/modules
+mv $DIR/tmp-code/enums $DIR/help/code/enums
 rm -rf $DIR/tmp-code
 echo "Documentation moved to $DIR/help/code"

--- a/help/code/enums/GristData.GristObjCode.md
+++ b/help/code/enums/GristData.GristObjCode.md
@@ -1,0 +1,101 @@
+# Enumeration: GristObjCode
+
+[GristData](../modules/GristData.md).GristObjCode
+
+Letter codes for CellValue types encoded as [code, args...] tuples.
+
+## Table of contents
+
+### Enumeration Members
+
+- [Censored](GristData.GristObjCode.md#censored)
+- [Date](GristData.GristObjCode.md#date)
+- [DateTime](GristData.GristObjCode.md#datetime)
+- [Dict](GristData.GristObjCode.md#dict)
+- [Exception](GristData.GristObjCode.md#exception)
+- [List](GristData.GristObjCode.md#list)
+- [LookUp](GristData.GristObjCode.md#lookup)
+- [Pending](GristData.GristObjCode.md#pending)
+- [Reference](GristData.GristObjCode.md#reference)
+- [ReferenceList](GristData.GristObjCode.md#referencelist)
+- [Skip](GristData.GristObjCode.md#skip)
+- [Unmarshallable](GristData.GristObjCode.md#unmarshallable)
+- [Versions](GristData.GristObjCode.md#versions)
+
+## Enumeration Members
+
+### Censored
+
+• **Censored** = ``"C"``
+
+___
+
+### Date
+
+• **Date** = ``"d"``
+
+___
+
+### DateTime
+
+• **DateTime** = ``"D"``
+
+___
+
+### Dict
+
+• **Dict** = ``"O"``
+
+___
+
+### Exception
+
+• **Exception** = ``"E"``
+
+___
+
+### List
+
+• **List** = ``"L"``
+
+___
+
+### LookUp
+
+• **LookUp** = ``"l"``
+
+___
+
+### Pending
+
+• **Pending** = ``"P"``
+
+___
+
+### Reference
+
+• **Reference** = ``"R"``
+
+___
+
+### ReferenceList
+
+• **ReferenceList** = ``"r"``
+
+___
+
+### Skip
+
+• **Skip** = ``"S"``
+
+___
+
+### Unmarshallable
+
+• **Unmarshallable** = ``"U"``
+
+___
+
+### Versions
+
+• **Versions** = ``"V"``


### PR DESCRIPTION
This fixes a warning about missing files when building the documentation.