### PR TITLE
fix some internal links, and add a script to check them

### DIFF
--- a/check_internal_links.sh
+++ b/check_internal_links.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "Running htmlproofer plugin to check for internal link problems."
+
+if [[ "$1" = "install" ]]; then
+  ./env/bin/pip install -e git+https://github.com/gristlabs/mkdocs-htmlproofer-plugin@style-on-headings#egg=mkdocs-htmlproofer-plugin
+  echo "Installed."
+  exit 0
+fi
+
+HTMLPROOFER_ENABLED=true \
+  HTMLPROOFER_OVERRIDE_USE_DIRECTORY_URLS=false \
+  ./env/bin/mkdocs build \
+  | grep -v "\[api.md\]" \
+  | grep -v "\[functions.md\]" \
+  | grep -v carousel
+
+echo "Remember this check is noisy, take with a grain of salt."
+echo "If you have not already, consider running:"
+echo "   ./check_internal_links.sh install"
+echo "to install a slightly patched verson of plugin."

--- a/check_internal_links.sh
+++ b/check_internal_links.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 echo "Running htmlproofer plugin to check for internal link problems."
 
 if [[ "$1" = "install" ]]; then

--- a/help/FAQ.md
+++ b/help/FAQ.md
@@ -46,7 +46,7 @@ All Grist users have access to a free personal account. The personal site is alw
 
 Documents shared with you will be shown in your personal site and do not count against the 10 document limit.
 
-You may navigate between your [personal site](teams.md#Understanding-Personal-Sites) and [team sites](teams.md) by clicking in the top-left corner to open a drop-down menu of sites to which you have access.
+You may navigate between your [personal site](teams.md#understanding-personal-sites) and [team sites](teams.md) by clicking in the top-left corner to open a drop-down menu of sites to which you have access.
 
 <center>*![Navigating between sites](images/faq/personal-and-team-site.png)*</center>
 
@@ -147,7 +147,7 @@ Guests, on the other hand, are invited to particular documents, but are not adde
 There are many ways to share Grist data with non-team members. 
 
 1. **Guests.** Each document may be shared with 2 guests (non-team members) at no additional cost.
-2. **Link Sharing.** In share settings, there is an option to turn on [public access](sharing.md#public-access). The public access role can be set to viewer or editor. Anyone with a link can view (or edit) your data. Those views would not count towards your plan's user count. The document is visible to anyone with the link, however, so use caution when working with sensitive data.
+2. **Link Sharing.** In share settings, there is an option to turn on [public access](sharing.md#public-access-and-link-sharing). The public access role can be set to viewer or editor. Anyone with a link can view (or edit) your data. Those views would not count towards your plan's user count. The document is visible to anyone with the link, however, so use caution when working with sensitive data.
 
 <center>*![Public access](images/faq/link-sharing.png)*</center>
 

--- a/help/access-rules.md
+++ b/help/access-rules.md
@@ -11,7 +11,7 @@ Every Grist document can be [shared with others](sharing.md)
 using the `Manage Users` option in the sharing
 menu (<span class="grist-icon" style="--icon: var(--icon-Share)"></span>).
 Users can be invited as Viewers, Editors, or Owners (see 
- [Sharing a document](sharing.md) for a refresher on those roles), or a document can be [shared publicly](sharing.md#public-access) with view or edit permissions.
+ [Sharing a document](sharing.md) for a refresher on those roles), or a document can be [shared publicly](sharing.md#public-access-and-link-sharing) with view or edit permissions.
 Sometimes, you need more nuance about who can see or edit individual
 parts of a document.  Access rules give us that power.
 

--- a/help/authorship.md
+++ b/help/authorship.md
@@ -7,8 +7,7 @@ tracks document changes in the Activity tab of Document History, but nevertheles
 convenient to have that information in tabular form available to formulas and filters,
 and authorship columns let you do that.
 
-A "Created By" column
-------------------------
+## A "Created By" column
 
 Suppose we want to fill a column automatically with the name of the creator
 of each record as they are added.  As a first step, add a column called 
@@ -33,8 +32,7 @@ column will be set to the name of the user creating it:
 ![a Created-By example](images/formulas/formulas-created-by-autofill.png)
 
 
-An "Updated By" column
--------------------------
+## An "Updated By" column
 
 If we want a column that stores who last edited a record (as opposed to its creator),
 the procedure is similar to that for [a "Created By" column](authorship.md#a-created-by-column),

--- a/help/col-refs.md
+++ b/help/col-refs.md
@@ -1,10 +1,9 @@
 <iframe width="560" height="315" src="https://www.youtube.com/embed/fkn2YCxEvTc?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Reference and Reference Lists
-==================================
+# Reference and Reference Lists
 
-Overview
---------
+## Overview
+
 Reference and Reference List columns in Grist allow one table to create an explicit reference
 to another. In the database world this is similar to a foreign key. In the spreadsheet world
 this is similar to a `VLOOKUP`, but much more powerful and easier to use.
@@ -12,8 +11,7 @@ this is similar to a `VLOOKUP`, but much more powerful and easier to use.
 In this guide we'll use the term **underlying table** for the table that lists all available values,
 and **referencing table** for the table that uses those values.
 
-Creating a new Reference column
--------------------------------
+## Creating a new Reference column
 
 Suppose we have a document with two tables, Clients and Projects.  The Clients table lists
 our clients - names, contacts, signing dates - and the Projects table lists projects we do for
@@ -57,8 +55,8 @@ highlighted as invalid:
 *![Invalid reference value](images/column-ref-invalid.png)*
 {: .screenshot-half }
 
-Adding values to a Reference column
------------------------------------
+## Adding values to a Reference column
+
 Sometimes it's useful to add a new value to the dropdown list without having to switch to the
 underlying table. Reference columns make it easy! Just type in the value you want add and select the
 `+` value in the dropdown list. Grist will automatically add a new record containing this value to
@@ -67,8 +65,8 @@ the underlying table and insert the proper reference:
 *![Add reference value](images/column-ref-add-value.png)*
 {: .screenshot-half }
 
-Converting Text column to Reference
------------------------------------
+## Converting Text column to Reference
+
 When working with existing data, it's common to have existing text values that should really be
 reference values. Don't worry, conversion is simple! Just change the column type to `Reference` and
 Grist will automatically find and substitute matching values for references. If some values are not
@@ -80,8 +78,8 @@ doesn't exist in the `Clients` table:
 
 ![Convert values after](images/column-ref-convert-after.png)
 
-Including multiple fields from a reference
-------------------------------------------
+## Including multiple fields from a reference
+
 A big benefit of reference columns is that they allow you to easily bring in multiple columns from
 the underlying table. In our example, if you wanted to bring in `$Client.Contact` to the `Projects`
 table, you can just select the `Contact` column from the `Add Reference Columns` section and it will be
@@ -106,8 +104,8 @@ in this example confuse you.
     `$Client.Contact` (singular). That's because the formula refers to the referencing column,
     **not** the underlying table. In our example, the referencing column is `Client`.
 
-Creating a new Reference List column
-------------------------------------
+## Creating a new Reference List column
+
 
 So far our example has only dealt with projects that have a single client. Suppose that
 we also have projects with multiple clients, and we'd like to maintain references to
@@ -124,8 +122,8 @@ hit "Apply" and the `Client` column will be ready to accept as many clients as y
 
 ![Reference List set-up](images/columns/columns-reference-list-transform.png)
 
-Editing values in a Reference List column
------------------------------------
+## Editing values in a Reference List column
+
 To make changes to a Reference List cell, simply double-click the cell or press the
 <code class="keys">*Enter*</code> key after you have selected the cell you want to
 edit. You can also start typing after selecting a cell if you'd like to write over

--- a/help/col-types.md
+++ b/help/col-types.md
@@ -3,8 +3,7 @@
 Columns and data types
 ======================
 
-Adding and removing columns
--------------------------------
+## Adding and removing columns
 
 Every Grist table, when first created, has three columns called A, B, and C.
 To rename a column, hover on the column header, click on the drop-down, then
@@ -38,8 +37,7 @@ reorder them.  You can also hide columns here.
 *![Visible columns](images/columns/columns-visible-columns.png)*
 {: .screenshot-half }
 
-Renaming columns
-------------------
+## Renaming columns
 
 You can rename columns in several ways.  One way is to
 click on the column header when the column is already selected.
@@ -55,8 +53,7 @@ can change it, though it will still need to be Python-friendly.  To change
 the name, deselect "Use Name as ID" if it is selected, and edit the "ID" entry now
 shown.
 
-Specifying a type
------------------
+## Specifying a type
 
 Grist columns have types, similar to other spreadsheets or databases.  The type of a column
 controls its appearance and the help Grist will offer you when editing cells.
@@ -91,8 +88,8 @@ referencing the invalid value will also display an error):
 ![Toggle out-of-vocabulary](images/columns/columns-toggle-oov.png)
 
 
-Supported types
----------------
+## Supported types
+
 Grist supports the following types:
 
 <div class='grist-mod__table'></div> <!-- For css styling via css/extra.css -->
@@ -111,8 +108,7 @@ Reference      | A reference column to another table.
 Reference List | A list of references to another table.
 Attachment     | Cells where you can place files or images.
 
-Text columns
---------------
+## Text columns
 
 You can put any text you like in this type of column.  For formatting,
 you can control alignment and word-wrap, text color and background color.
@@ -138,8 +134,7 @@ In general, the value until the last space is used as the link text, while the l
 Link formatting is particularly useful when links are generated using a formula such as:  
 `$Company + " " + $Website`{: .formula}
 
-Numeric columns
------------------
+## Numeric columns
 
 This type is for numbers, including floating-point numbers. In addition to controlling alignment
 and color, you can choose the number format, and the minimum and maximum number of digits to
@@ -168,14 +163,12 @@ The options under NUMBER FORMAT include:
   in accounting, and usually combined with `$` or `,` formats.
 
 
-Integer columns
------------------
+## Integer columns
 
 This is strictly for whole numbers.  It has the same options as
 the numeric type.
 
-Toggle columns
-----------------
+## Toggle columns
 
 This type is for storing true/false values.  The values can be shown
 as text, checkboxes, or switches.
@@ -185,8 +178,7 @@ as text, checkboxes, or switches.
 
 See also example in [Specifying a type](col-types.md#specifying-a-type).
 
-Date columns
-----
+## Date columns
 
 This type is for storing calendar dates (without a time of day component).
 More details in [Working with dates](dates.md).  You can choose the
@@ -196,8 +188,7 @@ format for dates, see the [date formatting reference](https://momentjs.com/docs/
 {: .screenshot-half }
 
 
-DateTime columns
----------
+## DateTime columns
 
 This type is for storing calendar dates plus time of day.
 More details in [Working with dates](dates.md).  You can choose the
@@ -206,8 +197,7 @@ format for dates, see the [date and time formatting reference](https://momentjs.
 *![Format date](images/columns/columns-format-datetime.png)*
 {: .screenshot-half }
 
-Choice columns
--------
+## Choice columns
 
 This type is for storing one of a set of valid values, where you get to
 specify the available values.
@@ -265,8 +255,7 @@ valid choice and into the cell in one step.
 *![Format choice](images/columns/columns-cell-choice.png)*
 {: .screenshot-half }
 
-Choice List columns
-------------
+## Choice List columns
 
 This type is for storing multiple values from a set of valid values, where you
 get to specify the available values.
@@ -295,8 +284,7 @@ while the cell is being edited. You can also use the arrow keys and the
 `Delete` key to navigate and delete choices, or simply click the delete icon
 when hovering your cursor over a choice.
 
-Reference columns
-----------
+## Reference columns
 
 This sets up a cross-reference to another table.  You can specify the
 table to reference, and a column within that table to show.
@@ -307,8 +295,7 @@ details.
 {: .screenshot-half }
 
 
-Reference List columns
-----------
+## Reference List columns
 
 Like [Reference columns](#reference-columns), but can store multiple
 references in a single cell.
@@ -319,8 +306,7 @@ There's a lot you can do with this kind of column, see
 {: .screenshot-half }
 
 
-Attachment columns
------------
+## Attachment columns
 
 This column type lets you insert entire files and images in cells.
 When images are added in cells, a preview thumbnail is shown in the

--- a/help/dates.md
+++ b/help/dates.md
@@ -16,8 +16,7 @@ objects](https://docs.python.org/3.9/library/datetime.html). That allows
 you to do some powerful things, but can be unexpected if you're not
 familiar with them.
 
-Making a date/time column
------------------------
+## Making a date/time column
 
 For a general introduction to setting the type of columns,
 see [Columns and data types](col-types.md).
@@ -46,8 +45,7 @@ and times.
 *![formulas-date-widget](images/formulas/formulas-date-widget.png)*
 {: .screenshot-half }
 
-Inserting the current date
------------------------------
+## Inserting the current date
 
 You can insert the current date in a cell using
 <code class="keys">*⌘* + **;** (semicolon)</code> (Mac) or <code class="keys">*Ctrl* + **;**</code> (Windows).
@@ -57,8 +55,8 @@ You can insert the current date and time using
 
 When editing a date cell, the date entry widget has a "today" button for today's date.
 
-Parsing dates from strings
---------------------------
+## Parsing dates from strings
+
 The [DATEVALUE](functions.md#datevalue) function converts a string that represents a date into a `datetime`
 object. It's simple to use and it will auto-detect different date formats:
 
@@ -109,8 +107,8 @@ dateutil.parser.parse($date_text, dayfirst=True)
 ```
 
 
-Date arithmetic
----------------
+## Date arithmetic
+
 Once you have a proper date column, often you'll want to do date arithmetic such as calculating the
 difference between two dates. The simplest way to do this is to use the [DATEDIF](functions.md#datedif)
 function which takes two dates and the unit of information to return (Days, Months, or Years).
@@ -146,8 +144,8 @@ DAYS($Last_day, $First_day)
     [`MONTH`](functions.md#month), [`HOUR`](functions.md#hour),
     and [many more](functions.md#date).
 
-Getting a part of the date
---------------------------
+## Getting a part of the date
+
 You've seen how to parse the date, display it in different formats, and do date arithmetic. But what
 if you want to get more information about a specific date, such as getting its day of the week?
 
@@ -164,8 +162,7 @@ Yet another option would be to reformat the date using Date Format in Column Opt
 (see the [date formatting reference](https://momentjs.com/docs/#/displaying/format/)).
 
 
-Time zones
------------
+## Time zones
 
 Values in `DateTime` columns represent moments in time. The same moment will look different in
 different timezones. In Grist, the timezone is set on each `DateTime` column. For instance, if the
@@ -185,8 +182,8 @@ If you do the same in a `Text` column, the date/time will be inserted as the tex
 the document's global timezone setting. Similarly, inserting the current date into a `Date` column
 will produce the current date according to the document's timezone.
 
-Additional resources
---------------------
+## Additional resources
+
 * [Python cheatsheet for strftime](http://strftime.org), for using with `strftime()` and
   `strptime()` in formulas.
 * [Date formatting cheatsheet](https://momentjs.com/docs/#/displaying/format/), for specifying the

--- a/help/embedding.md
+++ b/help/embedding.md
@@ -6,10 +6,10 @@
 
 Perhaps you'd like to list your product, prices and quantities on your website,
 or you want to display a pie chart of voting results that updates live. With
-[public access](sharing.md#public-access) turned on, you may embed your
+[public access](sharing.md#public-access-and-link-sharing) turned on, you may embed your
 Grist document on your own site.
 
-To do that, you first need to make it [public](sharing.md#public-access) and have
+To do that, you first need to make it [public](sharing.md#public-access-and-link-sharing) and have
 access to your website's code in order to place some HTML code in the desired location.
 
 If your site is hosted on some popular cloud CMS platform (like Blogger or WordPress),

--- a/help/examples/2021-04-link-keys.md
+++ b/help/examples/2021-04-link-keys.md
@@ -43,7 +43,7 @@ In the Students, Sessions, and Payments tables, add a column that ties each reco
 referenced family's UUID. Name these columns "UUID",
 with the simple formula `$Family.UUID`{: .formula}.
 Not sure how this works? Brush up on Grist's powerful [reference
-columns](../col-refs.md#top).
+columns](../col-refs.md#reference-and-reference-lists).
 
 ![Use reference columns to fetch UUID](images/2021-04-link-keys/private-tutor-reference-UUID.png)
 

--- a/help/formula-cheat-sheet.md
+++ b/help/formula-cheat-sheet.md
@@ -83,11 +83,11 @@ Let's break this down.
 `Interactions.lookupRecords(Contact=$id, Type="To-Do")` finds all records in the Interactions table where 
 the Contacts match and the Type is To-Do. This returns a list of records that we assign to the variable `items`. 
 
-Next, we use [dot notation](references-lookups.md#lookuprecords-and-dot-notation) to find all Dates assigned to the records in our `items` list. These dates are evaluated to find the minimum date. This is the value that is returned. So, we see the date of the task that is due the soonest. 
+Next, we use [dot notation](references-lookups.md#reference-columns-and-dot-notation) to find all Dates assigned to the records in our `items` list. These dates are evaluated to find the minimum date. This is the value that is returned. So, we see the date of the task that is due the soonest. 
 
 If there are no items in the list, nothing is returned and the field is left blank.
 
-In the MAX() example, the list has two items: `$Max_Students - $Count` and `0`, and the formula returns whichever is greater. In the min() example, the variable `items` is pulling a list of records based on the [lookupRecords](references-lookups.md#lookuprecords-and-len) arguments, listing the dates, and returning the smallest date. Note that this is a Python function. If we had written the formula as MIN(), a spreadsheet function, the formula would not work because the spreadsheet formula requires a very [specific format](functions.md#min).
+In the MAX() example, the list has two items: `$Max_Students - $Count` and `0`, and the formula returns whichever is greater. In the min() example, the variable `items` is pulling a list of records based on the [lookupRecords](references-lookups.md#lookuprecords) arguments, listing the dates, and returning the smallest date. Note that this is a Python function. If we had written the formula as MIN(), a spreadsheet function, the formula would not work because the spreadsheet formula requires a very [specific format](functions.md#min).
 
 
 </details>

--- a/help/formulas.md
+++ b/help/formulas.md
@@ -47,8 +47,7 @@ In Grist, a single formula applies to a whole column.
 You don't have to worry about filling it in for all rows,
 and can refer to values in the same row without fuss.
 
-Column behavior
----------------
+## Column behavior
 
 When we provide a formula for a column we tell Grist to update its value on every change
 in a document. We can no longer type a value into the cell, because its value is
@@ -86,8 +85,7 @@ Column` state.
 
 ![formulas-column-behavior-options](images/formulas/formulas-column-behavior-options.png)
 
-Python
--------
+## Python
 
 Grist formulas are written in Python, the most popular language for data science.
 The entirety of [Python's  standard library](https://docs.python.org/3.9/library/) is available
@@ -96,8 +94,7 @@ functions, with all-uppercase names. Here's the [full list of functions](functio
 Grist documents may use Python 2 or Python 3, see our [Python guide](python.md)
 for details.
 
-Formulas that operate over many rows
------------------------------------------
+## Formulas that operate over many rows
 
 If you are a spreadsheet user, you may find yourself wanting to have
 some special rows at the end of your table that have formulas
@@ -210,8 +207,7 @@ else:
   return $Quantity * $Unit_Price
 ```
 
-Code viewer
--------------
+## Code viewer
 
 Once you have a lot of formulas, or if you have been invited to a document
 and want to get an overview of its formulas, there is a code viewer
@@ -219,8 +215,7 @@ available with a pure Python summary of the document.
 
 ![formulas-code-view](images/formulas/formulas-code-view.png)
 
-Special values available in formulas
-------------------------------------
+## Special values available in formulas
 
 For those familiar with Python, here are the extra values available to
 you in Grist:
@@ -238,8 +233,7 @@ that are awkward in Python, those characters are replaced with an
 underscore.  Auto-complete may help you if you're not sure.  You
 can also control the "ids" of columns and tables in the right side panel.
 
-Freeze a formula column
------------------------
+## Freeze a formula column
 
 If you'd like to save the output of your formula as plain values, you can simply change
 column behavior from `Formula Column` to `Data Column`. First open the column options in
@@ -266,8 +260,7 @@ The side panel has lots of other handy settings, such as cell formatting
 (number of digits after decimal point, color, etc).  The options apply
 just as much to formula columns as to regular columns.
 
-Lookups
---------
+## Lookups
 
 Grist functions [lookupOne](functions.md#lookupone) and
 [lookupRecords](functions.md#lookuprecords) are useful for enumerating
@@ -301,8 +294,7 @@ whether [Summary tables](summary-tables.md) and
 [Summary formulas](summary-tables.md#summary-formulas) might be
 what you are looking for.
 
-Recursion
-----------
+## Recursion
 
 Lookups are handy for recursive formulas.  Suppose we have a table counting how many
 events we have per day, and want to add a cumulative sum of those event counts.
@@ -337,8 +329,7 @@ we defined `yesterday` here.
 To actually enter this formula in a cell, you'd use
 <code class="keys">*Shift* + *Enter*</code> to divide the lines.
 
-Trigger Formulas
-----------------
+## Trigger Formulas
 
 Formula columns are great for calculated values -- those determined by
 other data in the document. It may also be useful to store independent 

--- a/help/glossary.md
+++ b/help/glossary.md
@@ -155,7 +155,7 @@ An example of changing the sort order of a table is given in the
 
 The user menu is the menu that opens by clicking your profile icon in the top-right of Grist. From there you can manage your profile, add additional Grist accounts that you own, and see a list of team sites to which you have access.
 
-Depending on where you are, the user menu will contain additional options. For example, from a [personal site](teams.md#Understanding-Personal-Sites) you'll see the option to upgrade your plan to a [team site](teams.md). From a team site, depending on your role and permissions, you may be able to [manage billing](teams.md#billing-account) or [edit team members](team-sharing.md). From a document, you'll find an option to edit document settings.
+Depending on where you are, the user menu will contain additional options. For example, from a [personal site](teams.md#understanding-personal-sites) you'll see the option to upgrade your plan to a [team site](teams.md). From a team site, depending on your role and permissions, you may be able to [manage billing](teams.md#billing-account) or [edit team members](team-sharing.md). From a document, you'll find an option to edit document settings.
 
 *![document-settings](images/document-settings.png){: .screenshot4}*
 {: .screenshot-half }

--- a/help/limits.md
+++ b/help/limits.md
@@ -19,7 +19,7 @@ For team sites on both the Free and Pro plan, there is no limit on the number of
 
 Team members added to your team site may inherit access to workspaces or documents
 within that organization. Learn more about [team
-sharing](team-sharing.md#team-sharing).
+sharing](team-sharing.md).
 
 On both personal and team sites, each document may be shared with up to 2 free guests who do not affect the plan price even on the Pro plan.
 

--- a/help/references-lookups.md
+++ b/help/references-lookups.md
@@ -11,8 +11,7 @@ references the records on our Staff page.
 
 Keep in mind, it’s not just referencing the Full Name column but the entire record associated with the selected instructor. 
 
-Reference columns and dot notation
----------------
+## Reference columns and dot notation
 
 Using a Reference column within a formula can make it easy to get any data from the referenced record. To do this, we use dot notation. It uses the format `$A.B` where `A` is the name of the reference column and `B` is the name of the column in the referenced table that we want to pull data from.
 
@@ -30,8 +29,7 @@ The Class column references data from the Classes table. Therefore, the Class_Ti
 
 <span class="screenshot-large">*![classes-times](images/references-lookups/classes-times.png)*</span>
 
-Chaining
----------------
+## Chaining
 
 If the reference lookup returns a reference, this can be chained. 
 
@@ -62,8 +60,7 @@ Another way to see the name is to chain the dot-notation, as we did for phone: `
 
 <span class="screenshot-large">*![instructor-details](images/references-lookups/instructor-details.png)*</span>
 
-lookupOne
----------------
+## lookupOne
 
 Another way to point to a record is using `Table.lookupOne(...)` function. [lookupOne](https://support.getgrist.com/functions/#lookupone) allows you to look up a record by some fields, similar to Excel's VLOOKUP. In fact, Grist's version of VLOOKUP is merely an alias for lookupOne. lookupOne is rarely useful in Grist, because using a Reference type column is usually the preferred solution to connect records. However, on some occasions, lookupOne can be useful. 
 
@@ -102,8 +99,7 @@ It's often a good idea to create a column for the lookup result and change its t
 
 <span class="screenshot-large">*![sponsors-lookupone](images/references-lookups/sponsors-lookupone.png)*</span>
 
-lookupOne and dot notation
----------------
+## lookupOne and dot notation
 
 Because lookupOne is creating a reference to a record, we can use dot notation to look up additional fields in that record.
 
@@ -119,8 +115,7 @@ The entire formula would be `Sponsors.lookupOne(Contact_Email=$Registration_Emai
 
 Now, we have the Sponsor Level listed in the All Registrations table for those attendees whose emails also appear on the sponsor list.
 
-Understanding record sets
----------------
+## Understanding record sets
 
 Sometimes a record may reference multiple records in another table. Multiple references can be made with a Reference List Column. 
 
@@ -132,8 +127,8 @@ The only difference between a Reference column and a Reference List column is th
 
 <span class="screenshot-large">*![habit-tracker](images/references-lookups/habit-tracker.png)*</span>
 
-Reference lists and dot notation
----------------
+## Reference lists and dot notation
+
 Similar to references, you can use Dot Notation with reference lists. 
 
 Building on our prior [example](https://public.getgrist.com/6kTypo2FtSsf/Event-Sponsors-Attendees-References-and-Lookups/p/3) of attendees at a conference, suppose we have a list of registrants for an event and want to find the balance for each registrant. To do this, we can use dot notation.
@@ -148,8 +143,7 @@ With a reference list, dot-notation returns a list of all the selected field;
 
 `$Registrants.Balance` is a list of the Balances for each attendee in the list of `$Registrants`. This follows the format `$[A].[B]` where `[A]` is the name of the Reference List column and `[B]` is the name of the column in the referenced table you wish to pull data from. We'll learn how to find the sum of these balances in [Working with Record Sets](#working-with-record-sets).
 
-lookupRecords
----------------
+## lookupRecords
 
 You can also get a list of references using [lookupRecords](https://support.getgrist.com/functions/#lookuprecords).
 
@@ -180,8 +174,7 @@ We saw similar results using the [lookupOne](#lookupone) function. It's helpful 
 
 <span class="screenshot-large">*![lookup-records-reference-list](images/references-lookups/lookup-records-reference-list.png)*</span>
 
-Reverse lookups
----------------
+## Reverse lookups
 
 LookupRecords works a bit differently if a reference exists between two tables. With a reverse lookup, we can use the record ID to find a record. 
 
@@ -204,8 +197,7 @@ We use the existing reference, just in reverse - hence the name, Reverse Lookup.
 
 If you’d like a video walkthrough of a reverse lookup, we have an example in our [Build with Grist Webinar - Trigger Formulas v. Formulas](https://www.youtube.com/watch?v=0qVDPZd2w9I&t=788s).
 
-Working with record sets
----------------
+## Working with record sets
 
 lookupRecords can also be used within other formulas.
 

--- a/help/team-sharing.md
+++ b/help/team-sharing.md
@@ -1,5 +1,4 @@
-Team Sharing
-=========
+# Team Sharing
 
 We saw how to share individual documents with other users in the
 [Sharing](sharing.md) article.  Team sites give your further control,
@@ -22,8 +21,7 @@ All documents within the site will be accessible to those people,
 unless you turn off the "Inherit access" sharing option for individual [workspaces](workspaces.md)
 or [documents](sharing.md).
 
-Roles
--------------------------------
+## Roles
 
 There are three primary roles supported by Grist for team sites:
 
@@ -38,8 +36,8 @@ There are three primary roles supported by Grist for team sites:
 - **Owner**: gives a user complete permissions to the site's workspaces and documents,
   including their sharing settings.
 
-Billing Permissions
--------------------------------
+## Billing Permissions
+
 None of these roles give access to billing information or management.
 Billing plan managers can be added via the "Billing Account" option. 
 Open the user menu under your user icon, and select "Billing Account".

--- a/help/teams.md
+++ b/help/teams.md
@@ -24,15 +24,15 @@ Grist documents and shared with your team.
 ![team-sharing-team-site](images/team-sharing/team-sharing-team-site.png)
 
 If a colleague has shared a team site with you, you'll see the same thing,
-but depending on the [role](team-sharing.md#Roles) they chose for you, some options may be inactive.  If you need those options,
+but depending on the [role](team-sharing.md#roles) they chose for you, some options may be inactive.  If you need those options,
 ask your colleague to change your role.
 
 For a team site in which you are an Owner or Editor,
 you can [create documents](creating-doc.md) or [workspaces](workspaces.md). When your role is an
 Owner, you can immediately start [sharing](team-sharing.md) the site with others.
 
-Understanding Personal Sites
--------------------------------
+## Understanding Personal Sites
+
 Sites that begin with the "@" symbol are personal sites. All Grist accounts have a personal site.
 Your personal site is named using your name, and is always available at <https://docs.getgrist.com>.
 That’s also where you will find personal documents shared with you by others. Each document in a personal site may be [shared](sharing.md) with up to 2 Guests for free.
@@ -45,8 +45,7 @@ That’s also where you will find personal documents shared with you by others. 
 <em class="caption">a team site</em>
 {: .screenshot-half }
 
-Billing Account
--------------------------------
+## Billing Account
 
 If you created a team site on the Pro plan, or were added to it as a Billing Manager, then you may manage billing information, and edit your team site's name and subdomain from the billing account page. Open the [user menu](glossary.md#user-menu) and click on "Billing Account" to open a menu that looks like this. 
 

--- a/help/timestamps.md
+++ b/help/timestamps.md
@@ -5,8 +5,7 @@ Sometimes it is useful to have columns that store when individual records were c
 and updated.  This is useful later, for example to sort records by age or freshness.
 Grist lets you create such columns easily.
 
-A "Created At" column
-------------------------
+## A "Created At" column
 
 Suppose we want a column that stores when a record was created.
 As a first step, add a column called (for example) `Created At` and enter `NOW()`{: .formula} as
@@ -29,8 +28,7 @@ moment of their creation.
 
 ![a Created-At column](images/formulas/formulas-created-at-final.png)
 
-An "Updated At" column
--------------------------
+## An "Updated At" column
 
 If we want a column that stores when a record is updated (as opposed to created),
 the procedure is similar to that for [a "Created At" column](timestamps.md#a-created-at-column),

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,10 @@ site_url: "https://support.getgrist.com"
 repo_name: "GitHub"
 repo_url: "https://github.com/gristlabs/grist-help"
 
+# use directory urls (for prettiness) unless running htmlproofing
+# (which is confused by them).
+use_directory_urls: !ENV [HTMLPROOFER_OVERRIDE_USE_DIRECTORY_URLS, true]
+
 docs_dir: './help'
 # windmill is a theme maintained by Grist Labs in https://github.com/gristlabs/mkdocs-windmill
 theme:
@@ -154,6 +158,9 @@ extra_javascript:
 plugins:
   - search
   - awesome-pages
+  - htmlproofer:
+      enabled: !ENV [HTMLPROOFER_ENABLED, false]
+      validate_external_urls: false
 
 markdown_extensions:
   toc:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Markdown==3.2.2
 MarkupSafe==1.1.1
 mkdocs==1.2.3
 mkdocs-awesome-pages-plugin==2.7.0
+mkdocs-htmlproofer-plugin==0.8.0
 mkdocs-windmill==1.0.4
 nltk==3.5
 PyYAML==5.3.1


### PR DESCRIPTION
There are some internal links that have rusted, and aren't detected
as bad because only the anchor/hash is wrong, so the link reaches
a valid page (just not the right part of that page). This adds
a small script to apply the htmlproofer plugin to detect such
problems, and fixes a batch of them.

The plugin is a bit delicate. Headings in some files are migrated
from one markdown syntax to another to make the plugin happy.
I made a small fork of the plugin to make it deal better with
headers with style information. The plugin is not used by default,
and the fork is not installed by default, so as not to raise the
barrier of installing and using grist-help too much.