### PR TITLE
answer some self-managed Grist questions (python packages, stored files)

### DIFF
--- a/help/conditional-formatting.md
+++ b/help/conditional-formatting.md
@@ -20,7 +20,7 @@ We would also like to highlight breeders with 1 or 2 champion dogs in blue, and 
 
 To add conditional formatting to rows, go to the `ROW STYLE` section of the [creator panel](glossary.md#creator-panel) under the `Table > Widget` tab, and click on `Add conditional style`.
 
-![Conditional Row Styles](../images/newsletters/2022-08/conditional-row.png)
+![Conditional Row Styles](images/newsletters/2022-08/conditional-row.png)
 
 Order of Rules
 --------------


### PR DESCRIPTION
This answers some questions about how to install extra python packages (we don't have a good way to do this, but this consolidates answers elsewhere) and what files Grist stores in a persistent volume.