### PR TITLE
Adding `description` and `allowMultiple` fields description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,13 @@ To update `help/functions.md` from the documentation comments in Grist, run:
 
 It replaces content between `BEGIN mkpydocs`/`END mkpydocs` markers in `help/functions.md`. You
 can edit text outside of those markers directly.
+
+## Updating plugin API reference
+
+To update `help/code` from the documentation comments in Grist, run:
+
+```
+./build-plugin-api.sh <path-to-grist-checkout>
+```
+
+You need to first run `yarn install` in your Grist checkout directory.

--- a/help/code/interfaces/grist_plugin_api.ColumnToMap.md
+++ b/help/code/interfaces/grist_plugin_api.ColumnToMap.md
@@ -9,6 +9,7 @@ API definitions for CustomSection plugins.
 ### Properties
 
 - [allowMultiple](grist_plugin_api.ColumnToMap.md#allowmultiple)
+- [description](grist_plugin_api.ColumnToMap.md#description)
 - [name](grist_plugin_api.ColumnToMap.md#name)
 - [optional](grist_plugin_api.ColumnToMap.md#optional)
 - [title](grist_plugin_api.ColumnToMap.md#title)
@@ -21,6 +22,14 @@ API definitions for CustomSection plugins.
 • `Optional` **allowMultiple**: `boolean`
 
 Allow multiple column assignment, the result will be list of mapped table column names.
+
+___
+
+### description
+
+• `Optional` **description**: ``null`` \| `string`
+
+Optional long description of a column (used as a help text in section mapping).
 
 ___
 

--- a/help/widget-custom.md
+++ b/help/widget-custom.md
@@ -271,6 +271,8 @@ grist.ready({columns: [
     title: "Image link", // Friendly field name.
     optional: false, // Is this an optional field.
     type: "Text" // What type of column we expect.
+    description: "Some text" // Description of a field.
+    allowMultiple: false // Allows multiple column assignment.
   }
 ]});
 ```
@@ -285,6 +287,16 @@ a specific type, you need to set a `type` property. Here are all valid types:
 `Any`, `Int` (*Integer column*), `Numeric` (*Numeric column*), `Text`, `Date`, `DateTime`,
 `Bool` (*Toggle column*), `Choice`, `ChoiceList`, `Ref` (*Reference column*), `RefList`
 (*Reference List*), `Attachments`.
+
+Use `title` and `description` fields to help your users understand what is the purpose of
+the column. The `description` will be displayed just below the column name, and the
+`title` will be used as a column label. Both are optional and you can put there any text
+you want.
+
+If you need to map multiple columns (for example in a custom chart widget), you can use
+`allowMultiple` option. This will allow your users to pick a set of columns that will
+be returned as list of mapped table column names. The `mapColumnNames` helper will then
+return an array of mapped column values in a single field. 
 
 Suppose the user deletes a column or changes its type so that it will no longer match the
 type requested by the widget. In that case, Grist will automatically remove this column


### PR DESCRIPTION
Documenting the ability to add `descripton` and `allowMultiple` properties to custom widgets mapping.