### PR TITLE
add more metadata to pages

### DIFF
--- a/help/self-managed.md
+++ b/help/self-managed.md
@@ -1,3 +1,7 @@
+---
+description: The essentials of creating and maintaining a self-managed Grist installation.
+---
+
 # Self-Managed Grist
 
 [TOC]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,6 +162,7 @@ plugins:
   - htmlproofer:
       enabled: !ENV [HTMLPROOFER_ENABLED, false]
       validate_external_urls: false
+  - meta-descriptions
 
 markdown_extensions:
   toc:
@@ -169,3 +170,4 @@ markdown_extensions:
   admonition: {}
   smarty: {}
   extra: {}
+  meta: {}

--- a/overrides/base.html
+++ b/overrides/base.html
@@ -8,10 +8,19 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    {% if page and page.is_homepage %}<meta name="description" content="{{ config.site_description }}">{% endif %}
+    {% if page.meta and page.meta.description %}
+      <meta name="description" content="{{ page.meta.description|escape }}">
+      <meta property="og:description" content="{{ page.meta.description|escape }}">
+    {% else %}
+      <meta name="description" content="{{ config.site_description|escape }}">
+      <meta property="og:description" content="{{ config.site_description|escape }}">
+    {% endif %}
     {% if config.site_author %}<meta name="author" content="{{ config.site_author }}">{% endif %}
     {% if page and page.canonical_url %}<link rel="canonical" href="{{ page.canonical_url }}">{% endif %}
     <link rel="shortcut icon" href="{{ '/images/favicon.png'|url }}">
+    <meta name="thumbnail" content="{{ config.site_url ~ 'images/favicon.png' }}">
+    <meta property="og:image" content="{{ config.site_url ~ 'images/favicon.png' }}">
+    <!-- {{config.site_url}} -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
   {%- endblock %}
 

--- a/overrides/base.html
+++ b/overrides/base.html
@@ -20,7 +20,6 @@
     <link rel="shortcut icon" href="{{ '/images/favicon.png'|url }}">
     <meta name="thumbnail" content="{{ config.site_url ~ 'images/favicon.png' }}">
     <meta property="og:image" content="{{ config.site_url ~ 'images/favicon.png' }}">
-    <!-- {{config.site_url}} -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
   {%- endblock %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ MarkupSafe==1.1.1
 mkdocs==1.2.3
 mkdocs-awesome-pages-plugin==2.7.0
 mkdocs-htmlproofer-plugin==0.8.0
+mkdocs-meta-descriptions-plugin==2.0.0
 mkdocs-windmill==1.0.4
 nltk==3.5
 PyYAML==5.3.1


### PR DESCRIPTION
This adds image and description metadata to pages, so previews in the forums are more useful.

 * A "description" meta-data field is used if available (I added just one as a test).
 * Otherwise a plugin tries to assemble a description from the first paragraph on the page.
 * Otherwise if the plugin can't figure out a description, the site description is used.

I needed some absolute urls, and `config.site_url` is apparently always modified to end in a `/`, so I used that - not sure if it is the best way.