### PR TITLE
mention callback url in Auth0 SAML example; fix team name description

### DIFF
--- a/help/install/saml.md
+++ b/help/install/saml.md
@@ -55,7 +55,11 @@ within a shared volume. The key/cert pair were created following instructions he
 
   * [Auth0: use custom certificate to sign requests](https://auth0.com/docs/protocols/saml-protocol/saml-sso-integrations/sign-and-encrypt-saml-requests#use-custom-certificate-to-sign-requests)
   * [Auth0 as the SAML identity provider](https://auth0.com/docs/protocols/saml-protocol/saml-sso-integrations/sign-and-encrypt-saml-requests#auth0-as-the-saml-identity-provider)
- 
+
+In your Auth0 settings also make sure that:
+
+ * The "Application Callback URL" is set to `https://<grist-domain>/saml/assert`.
+
 ## Example: Authentik
 
 In [Authentik](https://goauthentik.io/), add a Provider called `Grist` with:

--- a/help/self-managed.md
+++ b/help/self-managed.md
@@ -161,8 +161,8 @@ docker run ...
   -e GRIST_SINGLE_ORG=cool-beans
 ```
 
-The name of the team should use only the characters A-Z, a-z, 0-9, and the
-hyphen (`-`).  You may also want to look into
+The name of the team should use only the lower-case characters a-z, the digits
+0-9, and the hyphen (`-`).  You may also want to look into
 [Custom styling](self-managed.md#how-do-i-customize-styling) to hide any UI elements
 you don't need.
 


### PR DESCRIPTION
This adds some clarifications that have come up:
  * The Auth0 SAML example didn't mention what the callback url should be.
  * The description of what GRIST_SINGLE_ORG can be set to was incorrect.

For `GRIST_SINGLE_ORG` a code fix is also coming to provide a better error message in case of problems.