### PR TITLE
Fix header on mobile

### DIFF
--- a/help/css/grist.css
+++ b/help/css/grist.css
@@ -371,6 +371,7 @@ body {
   width: unset;
   height: 48px;
   color: initial;
+  white-space: normal;
 }
 
 .wm-top-link, .wm-top-link:hover, .wm-top-link:active, .wm-top-link:visited, .wm-top-link:focus {

--- a/help/css/grist.css
+++ b/help/css/grist.css
@@ -113,9 +113,7 @@
 }
 
 /* a way to size images to half if intrinsic size; see https://stackoverflow.com/a/25026615/328565 */
-.screenshot-half { text-align: center; overflow: hidden; }
-.screenshot-half .screenshot-large { display: block; width: 150%; margin-left: -25%; }
-.screenshot-half .screenshot-full { display: block; width: 200%; margin-left: -50%; }
+.screenshot-half { text-align: center; overflow: hidden; width: 200%; margin-left: -50%; }
 .screenshot-half em { display: inline-block; }
 .screenshot-half em > img { width: 50%; margin: 0; }
 .screenshot-half .caption { display: block; text-align: center; }

--- a/help/css/grist.css
+++ b/help/css/grist.css
@@ -114,7 +114,8 @@
 
 /* a way to size images to half if intrinsic size; see https://stackoverflow.com/a/25026615/328565 */
 .screenshot-half { text-align: center; overflow: hidden; }
-.screenshot-half .screenshot-large { display: inline-block; width: 75%; }
+.screenshot-half .screenshot-large { display: block; width: 150%; margin-left: -25%; }
+.screenshot-half .screenshot-full { display: block; width: 200%; margin-left: -50%; }
 .screenshot-half em { display: inline-block; }
 .screenshot-half em > img { width: 50%; margin: 0; }
 .screenshot-half .caption { display: block; text-align: center; }

--- a/help/css/grist.css
+++ b/help/css/grist.css
@@ -113,7 +113,8 @@
 }
 
 /* a way to size images to half if intrinsic size; see https://stackoverflow.com/a/25026615/328565 */
-.screenshot-half { text-align: center; overflow: hidden; width: 200%; margin-left: -50%; }
+.screenshot-half { text-align: center; overflow: hidden; }
+.screenshot-half .screenshot-large { display: inline-block; width: 75%; }
 .screenshot-half em { display: inline-block; }
 .screenshot-half em > img { width: 50%; margin: 0; }
 .screenshot-half .caption { display: block; text-align: center; }
@@ -333,6 +334,10 @@ body {
 
 .wm-page-content p {
   margin-bottom: 15px;
+}
+
+.wm-page-content iframe {
+  max-width: 100%;
 }
 
 /*

--- a/help/exports.md
+++ b/help/exports.md
@@ -7,7 +7,7 @@ you can export that table as either an XLSX file or a CSV, a common interchange 
 To do this, open your document to the desired table or widget. Then click the three dot menu in the top right of the widget. 
 Select either "Download as CSV" or "Download as XLSX".
 
-<center>![Export Table](../images/exports/export-table.png)</center>
+<center>![Export Table](images/exports/export-table.png)</center>
 
 Your browser will then download a file containing a header row
 naming your columns, excluding any hidden columns or filtered-out rows, followed by all the
@@ -19,7 +19,7 @@ If you want to export all tables to Excel format, click the sharing icon
 (<span class="grist-icon" style="--icon: var(--icon-Share)"></span>)
 on the top right of the screen and select "Export XLSX".
 
-<center>![Export Document](../images/exports/export-xlsx.png)</center>
+<center>![Export Document](images/exports/export-xlsx.png)</center>
 
 Your browser will then download an Excel file, where each table is a separate sheet
 containing all rows, without any filters applied. To use this option you need to have full

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,7 @@ nav:
   - Pages and Tables:
     - Entering data: enter-data.md
     - Pages & widgets: page-widgets.md
-    - Raw data page: raw-data.md    
+    - Raw data page: raw-data.md
     - Search, sort & filter: search-sort-filter.md
     - Table widget: widget-table.md
     - Card & Card List: widget-card.md
@@ -80,11 +80,11 @@ nav:
     - GristConnect: install/grist-connect.md
   - News & updates:
     - Newsletters: newsletters.md
-    - 2022/09: newsletters/2022-09.md      
-    - 2022/08: newsletters/2022-08.md      
-    - 2022/07: newsletters/2022-07.md     
-    - 2022/06: newsletters/2022-06.md    
-    - 2022/05: newsletters/2022-05.md    
+    - 2022/09: newsletters/2022-09.md
+    - 2022/08: newsletters/2022-08.md
+    - 2022/07: newsletters/2022-07.md
+    - 2022/06: newsletters/2022-06.md
+    - 2022/05: newsletters/2022-05.md
     - 2022/04: newsletters/2022-04.md
     - 2022/03: newsletters/2022-03.md
     - 2022/02: newsletters/2022-02.md
@@ -152,6 +152,7 @@ extra:
       text: 'Community'
     - href: https://www.getgrist.com
       text: 'Back to Grist'
+      hide_on_small_screen: true
   google_analytics: ['GTM-5FDHKQ9', 'auto']
 extra_css:
   - css/grist.css

--- a/overrides/base.html
+++ b/overrides/base.html
@@ -78,7 +78,7 @@
 <body>
 {% include 'topbar.html' %}
 
-<div id="main-content" class="wm-page-top-frame">
+<div id="main-content">
   {% include 'nav-pane.html' %}
   <script>
     // Immediately expand parent items to show the selected page.

--- a/overrides/css/base.css
+++ b/overrides/css/base.css
@@ -142,7 +142,6 @@ body {
   top: 0;
   left: 0;
   margin-left: 0;
-  height: auto;
   box-shadow: 2px 3px 4px 0 grey;
 }
 
@@ -175,9 +174,6 @@ body {
     height: auto;
     overflow: visible;
   }
-  .wm-content-pane {
-    height: auto;
-  }
   .wm-small-hide {
     display: none;
   }
@@ -206,15 +202,11 @@ body {
     order: 1;
   }
 
-  body {
-    overflow: visible;
-  }
   .wm-toc-pane {
     display: none;
   }
   .wm-content-pane {
     padding-left: 0px;
-    overflow: visible;
   }
 }
 

--- a/overrides/css/base.css
+++ b/overrides/css/base.css
@@ -1,6 +1,5 @@
 body {
   background-color: #f8f8f8;
-  overflow: hidden;
 }
 
 /***********************************************************************
@@ -14,6 +13,8 @@ body {
   border-radius: 0px;
   margin-bottom: 0px;
   height: 50px;
+  width: 100%;
+  position: fixed;
   z-index: 2;
 }
 
@@ -106,7 +107,7 @@ body {
  ***********************************************************************/
 
 .wm-toc-pane {
-  position: absolute;
+  position: fixed;
   top: 0px;
   padding-top: 70px;
   height: 100%;
@@ -124,12 +125,7 @@ body {
 }
 
 .wm-content-pane {
-  position: absolute;
-  top: 0px;
   padding-top: 50px;
-  height: 100%;
-  width: 100%;
-  z-index: 0;
   padding-left: 250px;
   transition: padding-left 0.3s;
   /* required for iPhone to scroll the contained iframe */
@@ -137,7 +133,6 @@ body {
 }
 
 .wm-toc-pane.wm-toc-dropdown {
-  position: absolute;
   display: block;
   top: 0;
   left: 0;

--- a/overrides/topbar.html
+++ b/overrides/topbar.html
@@ -37,7 +37,7 @@
 
     {# CHANGED: Add links to topbar if have extra.home_links list with {href,text} properties #}
     {% for link in config.extra.home_links %}
-      <a href="{{ link.href }}" class="wm-top-tool wm-top-link pull-right wm-vcenter home-link">
+      <a href="{{ link.href }}" class="wm-top-tool wm-top-link pull-right wm-vcenter home-link {{"wm-small-hide" if link.hide_on_small_screen}}">
         <div class="wm-top-title">
           {{ link.text }}
         </div>


### PR DESCRIPTION
It also changes header to use position "fixed" and makes the articles scroll in a saner way as part of the page body.

Fixes videos to be limited to screen size.

Fixes two dubious (though working) image URLs. 