### PR TITLE
OpenAPI: Fix the OrgKey mixed type

### DIFF
--- a/api/grist.yml
+++ b/api/grist.yml
@@ -928,8 +928,8 @@ components:
   schemas:
     OrgKey:
       oneOf:
-        - integer
-        - string
+        - type: integer
+        - type: string
       description: This can be an integer id, or a string subdomain (e.g. `gristlabs`), or `current` if the org is implied by the domain in the url
     WorkspaceKey:
       type: integer


### PR DESCRIPTION
As per https://swagger.io/docs/specification/data-models/data-types/#mixed-type

The mixed types can be described using the combination of `oneOf` and a list of `type`s