### PR TITLE
add a rel=me link to verify ownership of this site for mastodon

### DIFF
--- a/overrides/base.html
+++ b/overrides/base.html
@@ -18,6 +18,7 @@
     {% if config.site_author %}<meta name="author" content="{{ config.site_author }}">{% endif %}
     {% if page and page.canonical_url %}<link rel="canonical" href="{{ page.canonical_url }}">{% endif %}
     <link rel="shortcut icon" href="{{ '/images/favicon.png'|url }}">
+    <link rel="me" href="https://fosstodon.org/@grist">
     <meta name="thumbnail" content="{{ config.site_url ~ 'images/favicon.png' }}">
     <meta property="og:image" content="{{ config.site_url ~ 'images/favicon.png' }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />


### PR DESCRIPTION
This adds a little bit of metadata so this site can be linked to in a verified way from a mastodon profile at https://fosstodon.org/@grist