### PR TITLE
tweak build-doc.sh script to work for netlify preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Grist Help Center
 
-(Just checking a change to netlify preview build)
-
 Repository for Grist documentation and tutorials.
 
 ## Where are the docs published?

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Grist Help Center
 
+(Just checking a change to netlify preview build)
+
 Repository for Grist documentation and tutorials.
 
 ## Where are the docs published?

--- a/build-doc.sh
+++ b/build-doc.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 set -euo pipefail
-source ./env/bin/activate
+
+# If a virtualenv is present, use it.
+# We don't use a virtualenv for netlify preview build.
+if [ -e env ]; then
+  source ./env/bin/activate
+fi
 
 mkdocs build


### PR DESCRIPTION
The changes the build-doc.sh script a little bit so it can be used for netlify previews. Using build-doc.sh for previews will make an upcoming transition related to translation work a little easier to review.