### PR TITLE
Fix publication to gh-pages

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -20,5 +20,9 @@ jobs:
       - name: Fetch origin/gh-pages
         run: git fetch origin gh-pages
 
+      - name: Building the documentation
+        run: python3 ./docs.py build-all
+
       - name: Publish live
-        run: mkdocs gh-deploy
+        run: |
+          ghp-import -m "Deployed ${GITHUB_SHA:0:7} with MkDocs version: $(pip show mkdocs | grep -Po "Version: \K.*")" -p site


### PR DESCRIPTION
This is an attempt to fix the issue with publishing to help-scout.

Inspired from this solution: https://github.com/mkdocs/mkdocs/issues/1165#issuecomment-718242360

~~I could not test to the end that it works, I would need to configure the github bot. [Here is what I could do so far](https://github.com/fflorent/grist-help/actions/runs/8084398245/job/22089587004).~~

Seems like it works:
 - https://github.com/fflorent/grist-help/actions/runs/8084590641/job/22090191710
 - https://github.com/fflorent/grist-help/commits/gh-pages/