### PR TITLE
Fix admonitions for translations

### DIFF
--- a/help/en/docs/authorship.md
+++ b/help/en/docs/authorship.md
@@ -10,7 +10,7 @@ and authorship columns let you do that.
 ## A "Created By" column
 
 Suppose we want to fill a column automatically with the name of the creator
-of each record as they are added.  As a first step, add a column called 
+of each record as they are added.  As a first step, add a column called
 (for example) `Created By`.  In the column options in the side panel
 (see [Columns](col-types.md) for a refresher), click
 `Set trigger formula` action.
@@ -48,5 +48,8 @@ is updated,a user name appears for that record:
 
 ![an Updated-By column](images/formulas/formulas-updated-by-autofill.png)
 
-!!! note "It is still possible for a user to manually edit cells in the `Created By` and `Updated By` columns. If you don't want that to be allowed, use [access rules](access-rules.md) to forbid it."
+!!! note ""
+    **It is still possible for a user to manually edit cells in the `Created By`
+    and `Updated By` columns. If you don't want that to be allowed,
+    use [access rules](access-rules.md) to forbid it.**
 

--- a/help/en/docs/install/forwarded-headers.md
+++ b/help/en/docs/install/forwarded-headers.md
@@ -5,7 +5,10 @@ You may have a middleware that does authentication and then passes identity
 on to web applications in a header. If you do, then Grist can be configured
 to respect that header.
 
-!!! warning "The redirection logic for authentication using forwarded headers currently assumes a [single team site](../self-managed.md#how-do-i-set-up-a-team) configuration, and may misbehave for multi-site configurations."
+!!! warning "Warning"
+    **The redirection logic for authentication using forwarded headers currently
+    assumes a [single team site](../self-managed.md#how-do-i-set-up-a-team)
+    configuration, and may misbehave for multi-site configurations.**
 
 To make this work, here is what you'll need to do:
 

--- a/help/en/docs/python.md
+++ b/help/en/docs/python.md
@@ -27,7 +27,9 @@ version of Python you have specified. We recommend caution in doing so.
 A formula that works as intended in one version of Python may give errors
 in another, or (worse) give the wrong results.
 
-!!! warning "Some formulas may fail or give wrong results if used with a version of Python that is different from the one for which they were written."
+!!! warning "Warning"
+    **Some formulas may fail or give wrong results if used with a version of Python
+    that is different from the one for which they were written.**
 
 Python 2 reached its end of life in January 2020, so if you look online for python help,
 the answers you find are more and more likely to be for Python 3. If you have a document

--- a/help/en/docs/self-managed.md
+++ b/help/en/docs/self-managed.md
@@ -413,7 +413,11 @@ The set of python packages available for use in formulas is currently
 not configurable. You can add packages anyway if you are willing to
 build and install your own version of the Grist.
 
-!!! warning "Grist documents made on an installation with custom python packages will not bring those packages with them if copied to a different installation. Formulas using custom python packages will give errors when those packages are unavailable."
+!!! warning "Warning"
+
+    **Grist documents made on an installation with custom python packages 
+    will not bring those packages with them if copied to a different installation. 
+    Formulas using custom python packages will give errors when those packages are unavailable.**
 
 Create an empty directory, and add the following into it, in a file called
 `Dockerfile`:

--- a/help/en/docs/timestamps.md
+++ b/help/en/docs/timestamps.md
@@ -39,7 +39,10 @@ pick and choose which columns to "count" as updates and which to ignore.
 
 ![an Updated-At column](images/formulas/formulas-updated-at.png)
 
-!!! note "It is still possible for a user to manually edit cells in the `Created At` and `Updated At` columns. If you don't want that to be allowed, use [access rules](access-rules.md) to forbid it."
+!!! note ""
+    **It is still possible for a user to manually edit cells in the `Created At`
+    and `Updated At` columns. If you don't want that to be allowed, use
+    [access rules](access-rules.md) to forbid it.**
 
 Here is an example of the new columns at work. One new record was added, for
 `Unorthodox Delivery Methods`, and a created and updated time were set for it


### PR DESCRIPTION
Admonitions have this form:

```
!!! warning|note "title"
    body
```

What is behind quotes may be translated with newlines due to weblate (see the end of #331).

I assume that:
 - for warnings, we may have an admonitions who have `Warning` in its title, so it can be translated
 - the content may remain in bold.

Modified admonitions are available here:
 - Authorship: https://deploy-preview-332--grist-help-preview.netlify.app/authorship/
 - Forwarded Headers: https://deploy-preview-332--grist-help-preview.netlify.app/install/forwarded-headers/
 - Python: https://deploy-preview-332--grist-help-preview.netlify.app/python/
 - Self-Managed: https://deploy-preview-332--grist-help-preview.netlify.app/self-managed
 - Timetamps: https://deploy-preview-332--grist-help-preview.netlify.app/timestamps/