### PR TITLE
make.com-urlchange-textdeletion

### DIFF
--- a/help/en/docs/integrators.md
+++ b/help/en/docs/integrators.md
@@ -8,7 +8,7 @@ include:
 - [Pabbly Connect](https://www.pabbly.com/connect/integrations/grist/)
 - [KonnectzIT](https://plan.konnectzit.com/feedback/grist-integration)
 - [n8n](https://n8n.io/integrations/n8n-nodes-base.grist)
-- [Make](https://www.make.com/en/integrations/grist) (formerly Integromat)
+- [Make](https://www.make.com/en/integrations/grist?utm_source=grist-app&utm_medium=partner&utm_campaign=grist-app-partner-program)
 
 ## Configuring Integrators
 


### PR DESCRIPTION
Make.com requiring changes to the URL and the elimination of "formerly Integromat"