### PR TITLE
remove user.Origin

### DIFF
--- a/help/en/docs/access-rules.md
+++ b/help/en/docs/access-rules.md
@@ -350,8 +350,6 @@ The `user` variable contains the following members:
  * `user.LinkKey`: an object with any access control URL parameters.  Access control URL
    parameters end in an underscore (which is then stripped).  Only available in the
    web client, not the API.
- * `user.Origin`: The content of the Origin request header.  Only available in the API,
-   not the web client.
  * `user.SessionID`: a unique string assigned to anonymous users for the duration of that user's session. For logged in users, `user.SessionID` is always `"u"` + the user's numeric id. 
 
 For an example of using the `user` variable, read [Default rules](access-rules.md#default-rules).


### PR DESCRIPTION
This was a feature that was never fleshed out, which has caused trouble, and which will shortly be removed: https://github.com/gristlabs/grist-core/pull/915

I propose removing the documentation for the feature entirely. Another option would be to strike it out and link to the discussion above. But given that we've no evidence anyone is using it, I've just deleted it. If someone complains we can revisit.