### PR TITLE
From weblate to gitlocalize

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-regular_issue.md
+++ b/.github/ISSUE_TEMPLATE/00-regular_issue.md
@@ -1,0 +1,7 @@
+---
+name: Bug report or feature request
+about: Use this template for any kind of issue
+title: ''
+labels: ''
+assignees: ''
+---

--- a/.github/ISSUE_TEMPLATE/10-help-translating.yml
+++ b/.github/ISSUE_TEMPLATE/10-help-translating.yml
@@ -1,0 +1,35 @@
+name: 🗺️ I would like to help translating
+description: Use this template to signify your desire to help translating
+title: "[GitLocalize] Please invite me to the translation team"
+assignees:
+ - fflorent
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You're willing to help us translating the documentation? Thank you! ✨
+        Please follow the few steps detailed below and we'll integrate you in the translation team as soon as possible
+  - type: checkboxes
+    id: git-localize-account-created
+    attributes:
+      label: GitLocalize account creation
+      description: Before submitting this issue, you should create an account on [GitLocalize](https://gitlocalize.com/) ([direct link to create an account](https://gitlocalize.com/auth/grant))
+      options:
+        - label: My account is created, you can invite me
+          required: true
+  - type: dropdown
+    id: languages
+    attributes:
+      label: languages you would like help translating
+      multiple: true
+      options:
+        - French
+        - Others (please detail below)
+    validations:
+      required: true
+  - type: input
+    id: other_languages
+    attributes:
+      label: Other languages (optional)
+      description: Is there languages non listed above for which you would like to translate the doc?

--- a/.github/ISSUE_TEMPLATE/10-help-translating.yml
+++ b/.github/ISSUE_TEMPLATE/10-help-translating.yml
@@ -32,4 +32,4 @@ body:
     id: other_languages
     attributes:
       label: Other languages (optional)
-      description: Is there languages non listed above for which you would like to translate the doc?
+      description: Are there languages non listed above for which you would like to translate the doc?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/docs.py
+++ b/docs.py
@@ -118,8 +118,6 @@ def new_lang(lang: str = typer.Argument(..., callback=lang_callback)):
 
   typer.secho(f"Successfully initialized: {new_path}", color=typer.colors.GREEN)
   update_languages()
-  typer.echo("If you are the owner of the weblate project, " +
-    "you may also run './docs.py update-languages --update-weblate' to update the allowed languages. If not, you may just go on and open a PR.", bold=True)
 
 @app.command()
 def build_lang(
@@ -177,54 +175,6 @@ def update_languages() -> None:
   Update the mkdocs.yml file Languages section including all the available languages.
   """
   update_config()
-
-@app.command()
-def update_weblate_filters() -> None:
-  """
-  Update the language filters (`language_regex` property), so only languages matching the regex can be added.
-  Therefore no language can be added in Weblate unless they are present in the alternate langs.
-
-  Also see:
-   - https://github.com/WeblateOrg/weblate/discussions/9703
-   - https://docs.weblate.org/en/latest/admin/projects.html#component-language-regex
-  """
-
-  api_key = os.environ.get("WEBLATE_API_KEY")
-  grist_help_project_slug = 'grist-help'
-  if not api_key:
-    api_key = getpass("Enter Weblate API Key (or set WEBLATE_API_KEY in environment): ")
-
-  s = requests.Session()
-  s.headers.update({
-    "Authorization": f"Token {api_key}",
-    "Accept": "application/json"
-  })
-  retries = Retry(total=3,
-                backoff_factor=0.1,
-                status_forcelist=[ 500, 502, 503, 504 ])
-  s.mount('https://', HTTPAdapter(max_retries=retries))
-
-  base_api_url = 'https://hosted.weblate.org/api'
-  resp = s.get(f'{base_api_url}/projects/{grist_help_project_slug}/components/?page_size=1000')
-  resp.raise_for_status()
-
-  slugs = [item['slug'] for item in resp.json().get('results')]
-  if len(slugs) == 1000:
-    raise typer.Abort('The number of components returned is more than 1000, the code should be updated to handle pagination')
-
-  config = get_alternate_langs_config()
-  languages = [item['code'] for item in config['extra']['alternate']]
-  language_filter=f'^({"|".join(languages)})$'
-
-  for slug in slugs:
-    component_url = f'{base_api_url}/components/{grist_help_project_slug}/{slug}/'
-    res = s.patch(component_url, json = { "language_regex": language_filter })
-    res.raise_for_status()
-    typer.echo(typer.style("SUCCESS:", fg=typer.colors.GREEN, bold=True) +
-      f" languages updated succesfully for {slug}")
-
-  typer.secho('ALL DONE for Weblate! Please note that weblate users will only be suggested to add allowed translations once the "Add missing translation" job has run (every 24h)', fg=typer
-.colors.GREEN, bold=True)
 
 @app.command()
 def serve() -> None:

--- a/help/en/MISSING-TRANSLATION.md
+++ b/help/en/MISSING-TRANSLATION.md
@@ -2,4 +2,4 @@ We're just getting started translating this language, sorry!
 
 We show partially translated languages to track progress.
 
-This page isn't translated yet. But the good news is that [you can join the translation community to help us 👋](https://hosted.weblate.org/engage/grist-help/){.internal-link target=_blank}.
+This page isn't translated yet. But the good news is that [you can join the translation community to help us 👋](https://github.com/gristlabs/grist-help/issues/new?template=10-help-translating.yml){.internal-link target=_blank}.

--- a/help/en/MISSING-TRANSLATION.md
+++ b/help/en/MISSING-TRANSLATION.md
@@ -2,4 +2,4 @@ We're just getting started translating this language, sorry!
 
 We show partially translated languages to track progress.
 
-This page isn't translated yet. But the good news is that [you can join the translation community to help us 👋](https://github.com/gristlabs/grist-help/issues/new?template=10-help-translating.yml){.internal-link target=_blank}.
+This page isn't translated yet. But the good news is that [you can join the translation community to help us 👋](__ISSUE_URL__){.internal-link target=_blank}.

--- a/help/fr/MACHINE-TRANSLATION.md
+++ b/help/fr/MACHINE-TRANSLATION.md
@@ -1,0 +1,3 @@
+La traduction proposée ici a été générée automatiquement, elle est donc imparfaite.
+
+Mais la bonne nouvelle est que [vous pouvez rejoindre la communauté de traduction pour nous aider 👋](https://github.com/gristlabs/grist-help/issues/new?template=10-help-translating.yml){.internal-link target=_blank}.

--- a/help/fr/MACHINE-TRANSLATION.md
+++ b/help/fr/MACHINE-TRANSLATION.md
@@ -1,3 +1,3 @@
-La traduction proposée ici a été générée automatiquement, elle est donc imparfaite.
+La traduction proposée ici a été générée automatiquement par le modèle d'intelligence artificielle GPT-4o. Il est probable qu'elle contienne des imperfections.
 
-Mais la bonne nouvelle est que [vous pouvez rejoindre la communauté de traduction pour nous aider 👋](https://github.com/gristlabs/grist-help/issues/new?template=10-help-translating.yml){.internal-link target=_blank}.
+Mais la bonne nouvelle est que [vous pouvez rejoindre la communauté de traduction pour améliorer le contenu fourni ici 👋](https://github.com/gristlabs/grist-help/issues/new?template=10-help-translating.yml){.internal-link target=_blank}.

--- a/help/fr/MACHINE-TRANSLATION.md
+++ b/help/fr/MACHINE-TRANSLATION.md
@@ -1,3 +1,3 @@
 La traduction proposée ici a été générée automatiquement par le modèle d'intelligence artificielle GPT-4o. Il est probable qu'elle contienne des imperfections.
 
-Mais la bonne nouvelle est que [vous pouvez rejoindre la communauté de traduction pour améliorer le contenu fourni ici 👋](https://github.com/gristlabs/grist-help/issues/new?template=10-help-translating.yml){.internal-link target=_blank}.
+Mais la bonne nouvelle est que [vous pouvez rejoindre la communauté de traduction pour améliorer le contenu fourni ici 👋](__ISSUE_URL__){.internal-link target=_blank}.

--- a/help/fr/MISSING-TRANSLATION.md
+++ b/help/fr/MISSING-TRANSLATION.md
@@ -2,4 +2,4 @@ Nous commençons tout juste à traduire la documentation pour cette langue, dés
 
 Nous affichons des pages traduites partiellement afin de suivre l'avancement.
 
-Cette page n'est pas encore traduite. Mais la bonne nouvelle est que [vous pouvez rejoindre la communauté de traduction pour nous aider 👋](https://github.com/gristlabs/grist-help/issues/new?template=10-help-translating.yml){.internal-link target=_blank}.
+Cette page n'est pas encore traduite. Mais la bonne nouvelle est que [vous pouvez rejoindre la communauté de traduction pour nous aider 👋](__ISSUE_URL__){.internal-link target=_blank}.

--- a/help/fr/MISSING-TRANSLATION.md
+++ b/help/fr/MISSING-TRANSLATION.md
@@ -2,4 +2,4 @@ Nous commençons tout juste à traduire la documentation pour cette langue, dés
 
 Nous affichons des pages traduites partiellement afin de suivre l'avancement.
 
-Cette page n'est pas encore traduite. Mais la bonne nouvelle est que [vous pouvez rejoindre la communauté de traduction pour nous aider 👋](https://hosted.weblate.org/engage/grist-help/){.internal-link target=_blank}.
+Cette page n'est pas encore traduite. Mais la bonne nouvelle est que [vous pouvez rejoindre la communauté de traduction pour nous aider 👋](https://github.com/gristlabs/grist-help/issues/new?template=10-help-translating.yml){.internal-link target=_blank}.

--- a/help/fr/docs/index.md
+++ b/help/fr/docs/index.md
@@ -4,7 +4,7 @@
 
     Nous affichons des pages traduites partiellement de sorte de suivre l'avancement.
 
-    Cette page n'est pas encore traduite. Mais la bonne nouvelle est que [vous pouvez rejoindre la communauté de traduction pour nous aider 👋](https://hosted.weblate.org/engage/grist-help/){.internal-link target=_blank}.
+    Cette page n'est pas encore traduite. Mais la bonne nouvelle est que [vous pouvez rejoindre la communauté de traduction pour nous aider 👋](https://github.com/gristlabs/grist-help/issues/new?template=10-help-translating.yml){.internal-link target=_blank}.
 
 
 

--- a/mkdocs-utils/hooks.py
+++ b/mkdocs-utils/hooks.py
@@ -17,11 +17,21 @@ from mkdocs.utils.yaml import yaml_load
 non_translated_sections = [] # Add the sections that are not translated here
 
 
-@lru_cache
-def get_missing_translation_content(docs_dir: str) -> str:
-  missing_translation_file_path = Path(docs_dir).parent / "MISSING-TRANSLATION.md"
+MISSING_TRANSLATION_FILENAME = "MISSING-TRANSLATION.md"
+MACHINE_TRANSLATION_FILENAME = "MACHINE-TRANSLATION.md"
+
+def _get_warning_file_content(docs_dir: str, filename: str):
+  missing_translation_file_path = Path(docs_dir).parent / filename
   missing_translation_content = missing_translation_file_path.read_text(encoding="utf-8")
   return "!!!warning\n\n" + indent(missing_translation_content, "    ")
+
+@lru_cache
+def get_missing_translation_content(docs_dir: str) -> str:
+  return _get_warning_file_content(docs_dir, MISSING_TRANSLATION_FILENAME)
+
+@lru_cache
+def get_automated_translation_content(docs_dir: str) -> str:
+  return _get_warning_file_content(docs_dir, MACHINE_TRANSLATION_FILENAME)
 
 
 class EnFile(File):
@@ -86,17 +96,24 @@ def on_files(files: Files, *, config: MkDocsConfig) -> Files:
   resolve_files(items=config.extra_javascript, files=files, config=config)
   return files
 
+def _inject_warning(markdown: str, warning: str, page: Page):
+  for excluded_section in non_translated_sections:
+    if page.file.src_path.startswith(excluded_section):
+      return markdown
+  missing_translation_content = warning
+  header = ""
+  body = markdown
+  if markdown.startswith("#"):
+    header, _, body = markdown.partition("\n\n")
+  return f"{header}\n\n{missing_translation_content}\n\n{body}"
+
 def on_page_markdown(
   markdown: str, *, page: Page, config: MkDocsConfig, **_: Any
 ) -> str:
+  docs_dir=Path(config.docs_dir)
   if isinstance(page.file, EnFile):
-    for excluded_section in non_translated_sections:
-      if page.file.src_path.startswith(excluded_section):
-        return markdown
-    missing_translation_content = get_missing_translation_content(config.docs_dir)
-    header = ""
-    body = markdown
-    if markdown.startswith("#"):
-      header, _, body = markdown.partition("\n\n")
-    return f"{header}\n\n{missing_translation_content}\n\n{body}"
+    return _inject_warning(markdown=markdown, page=page, warning=get_missing_translation_content(config.docs_dir))
+  elif docs_dir.parent.name != 'en' and (docs_dir.parent / MACHINE_TRANSLATION_FILENAME).exists():
+    return _inject_warning(markdown=markdown, page=page, warning=get_automated_translation_content(config.docs_dir))
+
   return markdown

--- a/mkdocs-utils/hooks.py
+++ b/mkdocs-utils/hooks.py
@@ -4,6 +4,8 @@
 # Original Author: Sebastián Ramírez and contributors
 
 import glob
+import yaml
+import urllib.parse
 from functools import lru_cache
 from pathlib import Path
 from textwrap import indent
@@ -21,17 +23,28 @@ MISSING_TRANSLATION_FILENAME = "MISSING-TRANSLATION.md"
 MACHINE_TRANSLATION_FILENAME = "MACHINE-TRANSLATION.md"
 
 def _get_warning_file_content(docs_dir: str, filename: str):
-  missing_translation_file_path = Path(docs_dir).parent / filename
-  missing_translation_content = missing_translation_file_path.read_text(encoding="utf-8")
-  return "!!!warning\n\n" + indent(missing_translation_content, "    ")
+  warning_file_path = Path(docs_dir).parent / filename
+  wanrning_content = warning_file_path.read_text(encoding="utf-8")
+  return "!!!warning\n\n" + indent(wanrning_content, "    ")
+
+@lru_cache
+def _get_issue_url_for_translation_commitment():
+  template_path = Path(__file__).parent.parent / ".github/ISSUE_TEMPLATE/10-help-translating.yml"
+  template = template_path.read_text(encoding="utf-8")
+  parsedTemplate = yaml.safe_load(template)
+  uriEncodedTitle = urllib.parse.quote_plus(parsedTemplate['title'])
+  uriEncodedTemplate = urllib.parse.quote_plus(template_path.name)
+  return "https://github.com/gristlabs/grist-help/issues/new?template=%s&title=%s" % (uriEncodedTemplate, uriEncodedTitle)
 
 @lru_cache
 def get_missing_translation_content(docs_dir: str) -> str:
-  return _get_warning_file_content(docs_dir, MISSING_TRANSLATION_FILENAME)
+  content = _get_warning_file_content(docs_dir, MISSING_TRANSLATION_FILENAME)
+  return content.replace('__ISSUE_URL__', _get_issue_url_for_translation_commitment())
 
 @lru_cache
 def get_automated_translation_content(docs_dir: str) -> str:
-  return _get_warning_file_content(docs_dir, MACHINE_TRANSLATION_FILENAME)
+  content = _get_warning_file_content(docs_dir, MACHINE_TRANSLATION_FILENAME)
+  return content.replace('__ISSUE_URL__', _get_issue_url_for_translation_commitment())
 
 
 class EnFile(File):


### PR DESCRIPTION
This PR:
 - removes any mention of weblate in favor of gitlocalize
 - removes a function related to weblate in the `docs.py` script
 - warns about the translation being generated
 - allow people asking to help translating through github using the dedicated template. Regular issues can still be open. [Preview available through my fork](https://github.com/fflorent/grist-help/issues/new/choose).

Fixes #370 