### PR TITLE
Fixes function searching and jumping

### DIFF
--- a/help/en/docs/css/grist.css
+++ b/help/en/docs/css/grist.css
@@ -319,10 +319,10 @@ body {
  * We want headers for the sake of searching, but don't want to see the huge padding and
  * surrounding empty paragraphs.
  */
-.wm-page-content summary h4,
-.wm-page-content summary p {
+.wm-page-content summary h4 + p:empty {
   display: none;
 }
+
 /* The <code> block that serves as a function header annoyingly gets auto-wrapped in a <p> */
 .wm-page-content summary p:not(:first-child) {
   display: inline-block;

--- a/help/en/docs/css/grist.css
+++ b/help/en/docs/css/grist.css
@@ -319,12 +319,12 @@ body {
  * We want headers for the sake of searching, but don't want to see the huge padding and
  * surrounding empty paragraphs.
  */
-.wm-page-content summary h4 + p:empty {
+.wm-page-content summary p:empty {
   display: none;
 }
 
 /* The <code> block that serves as a function header annoyingly gets auto-wrapped in a <p> */
-.wm-page-content summary p:not(:first-child) {
+.wm-page-content summary p:not(:first-child, :empty) {
   display: inline-block;
   margin: 0;
 }

--- a/help/en/docs/css/grist.css
+++ b/help/en/docs/css/grist.css
@@ -316,16 +316,16 @@ body {
 }
 
 /*
- * We want headers for the sake of searching, but don't want to see the huge padding and
- * surrounding empty paragraphs.
+ * Hide the empty paragraphs that are generated around headers in the expanding sections.
  */
 .wm-page-content summary p:empty {
   display: none;
 }
 
-/* The <code> block that serves as a function header annoyingly gets auto-wrapped in a <p> */
-.wm-page-content summary p:not(:first-child, :empty) {
-  display: inline-block;
+/*
+ * Clean up any extra space used by paragraphs in the header.
+ */
+.wm-page-content summary p {
   margin: 0;
 }
 

--- a/help/en/docs/functions.md
+++ b/help/en/docs/functions.md
@@ -62,7 +62,7 @@ def Name_Length(rec, table):
 ```
 </details>
 <details markdown><summary >
-#### <code>__$__*Field* or __rec__*.Field*</code> {: #_field }
+#### <code>__$__*Field* or __rec__*.Field*</code> {: #_field data-toc-label="$Field" }
 </summary>
 Access the field named "Field" of the current record. E.g. `$First_Name` or `rec.First_Name`.
 </details>
@@ -105,7 +105,7 @@ min(Tasks.lookupRecords(Owner="Bob").DueDate)
 You can get the number of records in a RecordSet using `len`, e.g. `len($group)`.
 </details>
 <details markdown><summary >
-#### <code>RecordSet.**find.\***(value)</code> {: #find_ }
+#### <code>RecordSet.**find.\***(value)</code> {: #find_ data-toc-label="RecordSet.find" }
 </summary>
 A set of methods for finding values in sorted sets of records, as returned by
 [`lookupRecords`](#lookuprecords). For example:
@@ -175,7 +175,7 @@ sum(r.Population for r in Countries.all)
 ```
 </details>
 <details markdown><summary >
-#### <code>UserTable.__lookupOne__(Field_In_Lookup_Table=value, ...)</code> {: #lookupone }
+#### <code>UserTable.__lookupOne__(Field_In_Lookup_Table=value, ...)</code> {: #lookupone data-toc-label="UserTable.lookupOne" }
 </summary>
 Returns a [Record](#record) matching the given field=value arguments. The value may be any
 expression,
@@ -204,7 +204,7 @@ Rates.lookupOne(Person=$id, order_by="-Date")      # Rate with the latest Date.
 ```
 </details>
 <details markdown><summary >
-#### <code>UserTable.__lookupRecords__(Field_In_Lookup_Table=value, ...)</code> {: #lookuprecords }
+#### <code>UserTable.__lookupRecords__(Field_In_Lookup_Table=value, ...)</code> {: #lookuprecords_2 data-toc-label="UserTable.lookupRecords" }
 </summary>
 Returns a [RecordSet](#recordset) matching the given field=value arguments. The value may be
 any expression,
@@ -248,13 +248,13 @@ Learn more about [lookupRecords](references-lookups.md#lookuprecords).
 </details>
 ### Cumulative
 <details markdown><summary >
-#### <code>__NEXT__(rec, *, group_by=(), order_by)</code> {: #next }
+#### <code>__NEXT__(rec, *, group_by=(), order_by)</code> {: #next data-toc-label="NEXT" }
 </summary>
 Finds the next record in the table according to the order specified by `order_by`, and
 grouping specified by `group_by`. See [`PREVIOUS`](#previous) for details.
 </details>
 <details markdown><summary >
-#### <code>__PREVIOUS__(rec, *, group_by=(), order_by)</code> {: #previous }
+#### <code>__PREVIOUS__(rec, *, group_by=(), order_by)</code> {: #previous data-toc-label="PREVIOUS" }
 </summary>
 Finds the previous record in the table according to the order specified by `order_by`, and
 grouping specified by `group_by`. Each of these arguments may be a column ID or a tuple of
@@ -290,7 +290,7 @@ PREVIOUS(rec, group_by=("Account", "Year"), order_by=("Date", "-Amount"))
 ```
 </details>
 <details markdown><summary >
-#### <code>__RANK__(rec, *, group_by=(), order_by, order='asc')</code> {: #rank }
+#### <code>__RANK__(rec, *, group_by=(), order_by, order='asc')</code> {: #rank data-toc-label="RANK" }
 </summary>
 Returns the rank (or position) of this record in the table according to the order specified by
 `order_by`, and grouping specified by `group_by`. See [`PREVIOUS`](#previous) for details of
@@ -311,7 +311,7 @@ decreasing score.
 </details>
 ### Date
 <details markdown><summary >
-#### <code>__DATE__(year, month, day)</code> {: #date }
+#### <code>__DATE__(year, month, day)</code> {: #date data-toc-label="DATE" }
 </summary>
 Returns the `datetime.datetime` object that represents a particular date.
 The DATE function is most useful in formulas where year, month, and day are formulas, not
@@ -358,7 +358,7 @@ datetime.date(2007, 12, 16)
 ```
 </details>
 <details markdown><summary >
-#### <code>__DATEADD__(start_date, days=0, months=0, years=0, weeks=0)</code> {: #dateadd }
+#### <code>__DATEADD__(start_date, days=0, months=0, years=0, weeks=0)</code> {: #dateadd data-toc-label="DATEADD" }
 </summary>
 Returns the date a given number of days, months, years, or weeks away from `start_date`. You may
 specify arguments in any order if you specify argument names. Use negative values to subtract.
@@ -389,7 +389,7 @@ datetime.date(2025, 3, 26)
 
 </details>
 <details markdown><summary >
-#### <code>__DATEDIF__(start_date, end_date, unit)</code> {: #datedif }
+#### <code>__DATEDIF__(start_date, end_date, unit)</code> {: #datedif data-toc-label="DATEDIF" }
 </summary>
 Calculates the number of days, months, or years between two dates.
 Unit indicates the type of information that you want returned:
@@ -433,7 +433,7 @@ The difference between 1 and 15, ignoring the months and the years of the dates 
 ```
 </details>
 <details markdown><summary >
-#### <code>__DATEVALUE__(date_string, tz=None)</code> {: #datevalue }
+#### <code>__DATEVALUE__(date_string, tz=None)</code> {: #datevalue data-toc-label="DATEVALUE" }
 </summary>
 Converts a date that is stored as text to a `datetime` object.
 
@@ -466,7 +466,7 @@ datetime.datetime(2003, 1, 2, 0, 0, tzinfo=moment.tzinfo('America/New_York'))
 ```
 </details>
 <details markdown><summary >
-#### <code>__DATE_TO_XL__(date_value)</code> {: #date_to_xl }
+#### <code>__DATE_TO_XL__(date_value)</code> {: #date_to_xl data-toc-label="DATE_TO_XL" }
 </summary>
 Converts a Python `date` or `datetime` object to the serial number as used by
 Excel, with December 30, 1899 as serial number 1.
@@ -490,7 +490,7 @@ See XL_TO_DATE for more explanation.
 ```
 </details>
 <details markdown><summary >
-#### <code>__DAY__(date)</code> {: #day }
+#### <code>__DAY__(date)</code> {: #day data-toc-label="DAY" }
 </summary>
 Returns the day of a date, as an integer ranging from 1 to 31. Same as `date.day`.
 
@@ -512,7 +512,7 @@ Returns the day of a date, as an integer ranging from 1 to 31. Same as `date.day
 
 </details>
 <details markdown><summary >
-#### <code>__DAYS__(end_date, start_date)</code> {: #days }
+#### <code>__DAYS__(end_date, start_date)</code> {: #days data-toc-label="DAYS" }
 </summary>
 Returns the number of days between two dates. Same as `(end_date - start_date).days`.
 
@@ -534,7 +534,7 @@ Returns the number of days between two dates. Same as `(end_date - start_date).d
 
 </details>
 <details markdown><summary >
-#### <code>__DTIME__(value, tz=None)</code> {: #dtime }
+#### <code>__DTIME__(value, tz=None)</code> {: #dtime data-toc-label="DTIME" }
 </summary>
 Returns the value converted to a python `datetime` object. The value may be a
 `string`, `date` (interpreted as midnight on that day), `time` (interpreted as a
@@ -577,7 +577,7 @@ datetime.datetime(2008, 1, 1, 0, 0, tzinfo=moment.tzinfo('America/New_York'))
 
 </details>
 <details markdown><summary >
-#### <code>__EDATE__(start_date, months)</code> {: #edate }
+#### <code>__EDATE__(start_date, months)</code> {: #edate data-toc-label="EDATE" }
 </summary>
 Returns the date that is the given number of months before or after `start_date`. Use
 EDATE to calculate maturity dates or due dates that fall on the same day of the month as the
@@ -611,7 +611,7 @@ datetime.date(2012, 3, 1)
 
 </details>
 <details markdown><summary >
-#### <code>__EOMONTH__(start_date, months)</code> {: #eomonth }
+#### <code>__EOMONTH__(start_date, months)</code> {: #eomonth data-toc-label="EOMONTH" }
 </summary>
 Returns the date for the last day of the month that is the indicated number of months before or
 after start_date. Use EOMONTH to calculate maturity dates or due dates that fall on the last day
@@ -640,7 +640,7 @@ datetime.date(2012, 3, 31)
 
 </details>
 <details markdown><summary >
-#### <code>__HOUR__(time)</code> {: #hour }
+#### <code>__HOUR__(time)</code> {: #hour data-toc-label="HOUR" }
 </summary>
 Same as `time.hour`.
 
@@ -662,7 +662,7 @@ Same as `time.hour`.
 
 </details>
 <details markdown><summary >
-#### <code>__ISOWEEKNUM__(date)</code> {: #isoweeknum }
+#### <code>__ISOWEEKNUM__(date)</code> {: #isoweeknum data-toc-label="ISOWEEKNUM" }
 </summary>
 Returns the ISO week number of the year for a given date.
 
@@ -679,7 +679,7 @@ Returns the ISO week number of the year for a given date.
 
 </details>
 <details markdown><summary >
-#### <code>__MINUTE__(time)</code> {: #minute }
+#### <code>__MINUTE__(time)</code> {: #minute data-toc-label="MINUTE" }
 </summary>
 Returns the minutes of `datetime`, as an integer from 0 to 59.
 Same as `time.minute`.
@@ -707,7 +707,7 @@ Same as `time.minute`.
 
 </details>
 <details markdown><summary >
-#### <code>__MONTH__(date)</code> {: #month }
+#### <code>__MONTH__(date)</code> {: #month data-toc-label="MONTH" }
 </summary>
 Returns the month of a date represented, as an integer from from 1 (January) to 12 (December).
 Same as `date.month`.
@@ -730,7 +730,7 @@ Same as `date.month`.
 
 </details>
 <details markdown><summary >
-#### <code>__MOONPHASE__(date, output='emoji')</code> {: #moonphase }
+#### <code>__MOONPHASE__(date, output='emoji')</code> {: #moonphase data-toc-label="MOONPHASE" }
 </summary>
 Returns the phase of the moon on the given date. The output defaults to a moon-phase emoji.
 
@@ -779,12 +779,12 @@ True
 
 </details>
 <details markdown><summary >
-#### <code>__NOW__(tz=None)</code> {: #now }
+#### <code>__NOW__(tz=None)</code> {: #now data-toc-label="NOW" }
 </summary>
 Returns the `datetime` object for the current time.
 </details>
 <details markdown><summary >
-#### <code>__SECOND__(time)</code> {: #second }
+#### <code>__SECOND__(time)</code> {: #second data-toc-label="SECOND" }
 </summary>
 Returns the seconds of `datetime`, as an integer from 0 to 59.
 Same as `time.second`.
@@ -807,12 +807,12 @@ Same as `time.second`.
 
 </details>
 <details markdown><summary >
-#### <code>__TODAY__(tz=None)</code> {: #today }
+#### <code>__TODAY__(tz=None)</code> {: #today data-toc-label="TODAY" }
 </summary>
 Returns the `date` object for the current date.
 </details>
 <details markdown><summary >
-#### <code>__WEEKDAY__(date, return_type=1)</code> {: #weekday }
+#### <code>__WEEKDAY__(date, return_type=1)</code> {: #weekday data-toc-label="WEEKDAY" }
 </summary>
 Returns the day of the week corresponding to a date. The day is given as an integer, ranging
 from 1 (Sunday) to 7 (Saturday), by default.
@@ -857,7 +857,7 @@ Return_type determines the type of the returned value.
 ```
 </details>
 <details markdown><summary >
-#### <code>__WEEKNUM__(date, return_type=1)</code> {: #weeknum }
+#### <code>__WEEKNUM__(date, return_type=1)</code> {: #weeknum data-toc-label="WEEKNUM" }
 </summary>
 Returns the week number of a specific date. For example, the week containing January 1 is the
 first week of the year, and is numbered week 1.
@@ -898,7 +898,7 @@ Return_type determines which week is considered the first week of the year.
 ```
 </details>
 <details markdown><summary >
-#### <code>__XL_TO_DATE__(value, tz=None)</code> {: #xl_to_date }
+#### <code>__XL_TO_DATE__(value, tz=None)</code> {: #xl_to_date data-toc-label="XL_TO_DATE" }
 </summary>
 Converts a provided Excel serial number representing a date into a `datetime` object.
 Value is interpreted as the number of days since December 30, 1899.
@@ -927,7 +927,7 @@ datetime.datetime(2012, 3, 14, 1, 30, tzinfo=moment.tzinfo('America/New_York'))
 ```
 </details>
 <details markdown><summary >
-#### <code>__YEAR__(date)</code> {: #year }
+#### <code>__YEAR__(date)</code> {: #year data-toc-label="YEAR" }
 </summary>
 Returns the year corresponding to a date as an integer.
 Same as `date.year`.
@@ -950,7 +950,7 @@ Same as `date.year`.
 
 </details>
 <details markdown><summary >
-#### <code>__YEARFRAC__(start_date, end_date, basis=0)</code> {: #yearfrac }
+#### <code>__YEARFRAC__(start_date, end_date, basis=0)</code> {: #yearfrac data-toc-label="YEARFRAC" }
 </summary>
 Calculates the fraction of the year represented by the number of whole days between two dates.
 
@@ -999,14 +999,14 @@ Fraction between same dates, using the Actual/365 basis argument. Uses a 365 day
 </details>
 ### Info
 <details>
-#### <code>__CELL__(info_type, reference)</code> {: #cell }
+#### <code>__CELL__(info_type, reference)</code> {: #cell data-toc-label="CELL" }
 </summary>
 Returns the requested information about the specified cell. This is not implemented in Grist
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__ISBLANK__(value)</code> {: #isblank }
+#### <code>__ISBLANK__(value)</code> {: #isblank data-toc-label="ISBLANK" }
 </summary>
 Returns whether a value refers to an empty cell. It isn't implemented in Grist. To check for an
 empty string, use `value == ""`.
@@ -1014,7 +1014,7 @@ empty string, use `value == ""`.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details markdown><summary >
-#### <code>__ISEMAIL__(value)</code> {: #isemail }
+#### <code>__ISEMAIL__(value)</code> {: #isemail data-toc-label="ISEMAIL" }
 </summary>
 Returns whether a value is a valid email address.
 
@@ -1044,7 +1044,7 @@ False
 ```
 </details>
 <details markdown><summary >
-#### <code>__ISERR__(value)</code> {: #iserr }
+#### <code>__ISERR__(value)</code> {: #iserr data-toc-label="ISERR" }
 </summary>
 Checks whether a value is an error. In other words, it returns true
 if using `value` directly would raise an exception.
@@ -1068,7 +1068,7 @@ False
 ```
 </details>
 <details markdown><summary >
-#### <code>__ISERROR__(value)</code> {: #iserror }
+#### <code>__ISERROR__(value)</code> {: #iserror data-toc-label="ISERROR" }
 </summary>
 Checks whether a value is an error or an invalid value. It is similar to `ISERR`, but also
 returns true for an invalid value such as NaN or a text value in a Numeric column.
@@ -1092,7 +1092,7 @@ True
 ```
 </details>
 <details markdown><summary >
-#### <code>__ISLOGICAL__(value)</code> {: #islogical }
+#### <code>__ISLOGICAL__(value)</code> {: #islogical data-toc-label="ISLOGICAL" }
 </summary>
 Checks whether a value is `True` or `False`.
 
@@ -1124,7 +1124,7 @@ False
 
 </details>
 <details markdown><summary >
-#### <code>__ISNA__(value)</code> {: #isna }
+#### <code>__ISNA__(value)</code> {: #isna data-toc-label="ISNA" }
 </summary>
 Checks whether a value is the error `#N/A`.
 
@@ -1151,7 +1151,7 @@ False
 
 </details>
 <details markdown><summary >
-#### <code>__ISNONTEXT__(value)</code> {: #isnontext }
+#### <code>__ISNONTEXT__(value)</code> {: #isnontext data-toc-label="ISNONTEXT" }
 </summary>
 Checks whether a value is non-textual.
 
@@ -1188,7 +1188,7 @@ True
 
 </details>
 <details markdown><summary >
-#### <code>__ISNUMBER__(value)</code> {: #isnumber }
+#### <code>__ISNUMBER__(value)</code> {: #isnumber data-toc-label="ISNUMBER" }
 </summary>
 Checks whether a value is a number.
 
@@ -1234,7 +1234,7 @@ False
 ```
 </details>
 <details markdown><summary >
-#### <code>__ISREF__(value)</code> {: #isref }
+#### <code>__ISREF__(value)</code> {: #isref data-toc-label="ISREF" }
 </summary>
 Checks whether a value is a table record.
 
@@ -1256,7 +1256,7 @@ False
 
 </details>
 <details markdown><summary >
-#### <code>__ISREFLIST__(value)</code> {: #isreflist }
+#### <code>__ISREFLIST__(value)</code> {: #isreflist data-toc-label="ISREFLIST" }
 </summary>
 Checks whether a value is a [`RecordSet`](#recordset),
 the type of values in Reference List columns.
@@ -1279,7 +1279,7 @@ False
 
 </details>
 <details markdown><summary >
-#### <code>__ISTEXT__(value)</code> {: #istext }
+#### <code>__ISTEXT__(value)</code> {: #istext data-toc-label="ISTEXT" }
 </summary>
 Checks whether a value is text.
 
@@ -1316,7 +1316,7 @@ False
 
 </details>
 <details markdown><summary >
-#### <code>__ISURL__(value)</code> {: #isurl }
+#### <code>__ISURL__(value)</code> {: #isurl data-toc-label="ISURL" }
 </summary>
 Checks whether a value is a valid URL. It does not need to be fully qualified, or to include
 "http://" and "www". It does not follow a standard, but attempts to work similarly to ISURL in
@@ -1346,7 +1346,7 @@ False
 ```
 </details>
 <details markdown><summary >
-#### <code>__N__(value)</code> {: #n }
+#### <code>__N__(value)</code> {: #n data-toc-label="N" }
 </summary>
 Returns the value converted to a number. True/False are converted to 1/0. A date is converted to
 Excel-style serial number of the date. Anything else is converted to 0.
@@ -1384,7 +1384,7 @@ Excel-style serial number of the date. Anything else is converted to 0.
 
 </details>
 <details markdown><summary >
-#### <code>__NA__()</code> {: #na }
+#### <code>__NA__()</code> {: #na data-toc-label="NA" }
 </summary>
 Returns the "value not available" error, `#N/A`.
 
@@ -1396,7 +1396,7 @@ True
 
 </details>
 <details markdown><summary >
-#### <code>__PEEK__(func)</code> {: #peek }
+#### <code>__PEEK__(func)</code> {: #peek data-toc-label="PEEK" }
 </summary>
 Evaluates the given expression without creating dependencies
 or requiring that referenced values are up to date, using whatever value it finds in a cell.
@@ -1409,7 +1409,7 @@ already stored in `$B` without requiring that `$B` is first calculated to the la
 Therefore `A` will be calculated first, and `B` can use `$A` without problems.
 </details>
 <details markdown><summary >
-#### <code>__RECORD__(record_or_list, dates_as_iso=False, expand_refs=0)</code> {: #record }
+#### <code>__RECORD__(record_or_list, dates_as_iso=False, expand_refs=0)</code> {: #record_2 data-toc-label="RECORD" }
 </summary>
 Returns a Python dictionary with all fields in the given record. If a list of records is given,
 returns a list of corresponding Python dictionaries.
@@ -1436,13 +1436,13 @@ RECORD(People.lookupRecords(Department="HR"))
 ```
 </details>
 <details>
-#### <code>__REQUEST__(url, params=None, headers=None, method='GET', data=None, json=None)</code> {: #request }
+#### <code>__REQUEST__(url, params=None, headers=None, method='GET', data=None, json=None)</code> {: #request data-toc-label="REQUEST" }
 </summary>
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__TYPE__(value)</code> {: #type }
+#### <code>__TYPE__(value)</code> {: #type data-toc-label="TYPE" }
 </summary>
 Returns a number associated with the type of data passed into the function. This is not
 implemented in Grist. Use `isinstance(value, type)` or `type(value)`.
@@ -1451,7 +1451,7 @@ implemented in Grist. Use `isinstance(value, type)` or `type(value)`.
 </details>
 ### Logical
 <details markdown><summary >
-#### <code>__AND__(logical_expression, *logical_expressions)</code> {: #and }
+#### <code>__AND__(logical_expression, *logical_expressions)</code> {: #and data-toc-label="AND" }
 </summary>
 Returns True if all of the arguments are logically true, and False if any are false.
 Same as `all([value1, value2, ...])`.
@@ -1484,7 +1484,7 @@ False
 
 </details>
 <details markdown><summary >
-#### <code>__FALSE__()</code> {: #false }
+#### <code>__FALSE__()</code> {: #false data-toc-label="FALSE" }
 </summary>
 Returns the logical value `False`. You may also use the value `False` directly. This
 function is provided primarily for compatibility with other spreadsheet programs.
@@ -1497,7 +1497,7 @@ False
 
 </details>
 <details markdown><summary >
-#### <code>__IF__(logical_expression, value_if_true, value_if_false)</code> {: #if }
+#### <code>__IF__(logical_expression, value_if_true, value_if_false)</code> {: #if data-toc-label="IF" }
 </summary>
 Returns one value if a logical expression is `True` and another if it is `False`.
 
@@ -1540,7 +1540,7 @@ to evaluate to `1` rather than raise an exception.
 ```
 </details>
 <details markdown><summary >
-#### <code>__IFERROR__(value, value_if_error='')</code> {: #iferror }
+#### <code>__IFERROR__(value, value_if_error='')</code> {: #iferror data-toc-label="IFERROR" }
 </summary>
 Returns the first argument if it is not an error value, otherwise returns the second argument if
 present, or a blank if the second argument is absent.
@@ -1569,7 +1569,7 @@ NOTE: Grist handles values that raise an exception by wrapping them to use lazy 
 ```
 </details>
 <details markdown><summary >
-#### <code>__NOT__(logical_expression)</code> {: #not }
+#### <code>__NOT__(logical_expression)</code> {: #not data-toc-label="NOT" }
 </summary>
 `True`. Same as `not logical_expression`.
 
@@ -1586,7 +1586,7 @@ True
 
 </details>
 <details markdown><summary >
-#### <code>__OR__(logical_expression, *logical_expressions)</code> {: #or }
+#### <code>__OR__(logical_expression, *logical_expressions)</code> {: #or data-toc-label="OR" }
 </summary>
 Returns True if any of the arguments is logically true, and false if all of the
 arguments are false.
@@ -1630,7 +1630,7 @@ True
 
 </details>
 <details markdown><summary >
-#### <code>__TRUE__()</code> {: #true }
+#### <code>__TRUE__()</code> {: #true data-toc-label="TRUE" }
 </summary>
 Returns the logical value `True`. You may also use the value `True` directly. This
 function is provided primarily for compatibility with other spreadsheet programs.
@@ -1644,7 +1644,7 @@ True
 </details>
 ### Lookup
 <details markdown><summary >
-#### <code>UserTable.__lookupOne__(Field_In_Lookup_Table=value, ...)</code> {: #lookupone }
+#### <code>UserTable.__lookupOne__(Field_In_Lookup_Table=value, ...)</code> {: #lookupone_2 data-toc-label="UserTable.lookupOne" }
 </summary>
 Returns a [Record](#record) matching the given field=value arguments. The value may be any
 expression,
@@ -1673,7 +1673,7 @@ Rates.lookupOne(Person=$id, order_by="-Date")      # Rate with the latest Date.
 ```
 </details>
 <details markdown><summary >
-#### <code>UserTable.__lookupRecords__(Field_In_Lookup_Table=value, ...)</code> {: #lookuprecords }
+#### <code>UserTable.__lookupRecords__(Field_In_Lookup_Table=value, ...)</code> {: #lookuprecords data-toc-label="UserTable.lookupRecords" }
 </summary>
 Returns a [RecordSet](#recordset) matching the given field=value arguments. The value may be
 any expression,
@@ -1716,35 +1716,35 @@ value.
 Learn more about [lookupRecords](references-lookups.md#lookuprecords).
 </details>
 <details>
-#### <code>__ADDRESS__(row, column, absolute_relative_mode, use_a1_notation, sheet)</code> {: #address }
+#### <code>__ADDRESS__(row, column, absolute_relative_mode, use_a1_notation, sheet)</code> {: #address data-toc-label="ADDRESS" }
 </summary>
 Returns a cell reference as a string.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__CHOOSE__(index, choice1, choice2)</code> {: #choose }
+#### <code>__CHOOSE__(index, choice1, choice2)</code> {: #choose data-toc-label="CHOOSE" }
 </summary>
 Returns an element from a list of choices based on index.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__COLUMN__(cell_reference=None)</code> {: #column }
+#### <code>__COLUMN__(cell_reference=None)</code> {: #column data-toc-label="COLUMN" }
 </summary>
 Returns the column number of a specified cell, with `A=1`.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__COLUMNS__(range)</code> {: #columns }
+#### <code>__COLUMNS__(range)</code> {: #columns data-toc-label="COLUMNS" }
 </summary>
 Returns the number of columns in a specified array or range.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details markdown><summary >
-#### <code>__CONTAINS__(value, match_empty=no_match_empty)</code> {: #contains }
+#### <code>__CONTAINS__(value, match_empty=no_match_empty)</code> {: #contains data-toc-label="CONTAINS" }
 </summary>
 Use this marker with [UserTable.lookupRecords](#lookuprecords) to find records
 where a field of a list type (such as `Choice List` or `Reference List`) contains the given value.
@@ -1774,77 +1774,77 @@ If `g` is `''` (i.e. equal to `match_empty`) then the column `genre` in the retu
 will either be an empty list (or other container) or a list containing `g` as usual.
 </details>
 <details>
-#### <code>__GETPIVOTDATA__(value_name, any_pivot_table_cell, original_column_1, pivot_item_1=None, *args)</code> {: #getpivotdata }
+#### <code>__GETPIVOTDATA__(value_name, any_pivot_table_cell, original_column_1, pivot_item_1=None, *args)</code> {: #getpivotdata data-toc-label="GETPIVOTDATA" }
 </summary>
 Extracts an aggregated value from a pivot table that corresponds to the specified row and column headings.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__HLOOKUP__(search_key, range, index, is_sorted)</code> {: #hlookup }
+#### <code>__HLOOKUP__(search_key, range, index, is_sorted)</code> {: #hlookup data-toc-label="HLOOKUP" }
 </summary>
 Horizontal lookup. Searches across the first row of a range for a key and returns the value of a specified cell in the column found.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__HYPERLINK__(url, link_label)</code> {: #hyperlink }
+#### <code>__HYPERLINK__(url, link_label)</code> {: #hyperlink data-toc-label="HYPERLINK" }
 </summary>
 Creates a hyperlink inside a cell.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__INDEX__(reference, row, column)</code> {: #index }
+#### <code>__INDEX__(reference, row, column)</code> {: #index data-toc-label="INDEX" }
 </summary>
 Returns the content of a cell, specified by row and column offset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__INDIRECT__(cell_reference_as_string)</code> {: #indirect }
+#### <code>__INDIRECT__(cell_reference_as_string)</code> {: #indirect data-toc-label="INDIRECT" }
 </summary>
 Returns a cell reference specified by a string.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__LOOKUP__(search_key, search_range_or_search_result_array, result_range=None)</code> {: #lookup }
+#### <code>__LOOKUP__(search_key, search_range_or_search_result_array, result_range=None)</code> {: #lookup data-toc-label="LOOKUP" }
 </summary>
 Looks through a row or column for a key and returns the value of the cell in a result range located in the same position as the search row or column.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__MATCH__(search_key, range, search_type)</code> {: #match }
+#### <code>__MATCH__(search_key, range, search_type)</code> {: #match data-toc-label="MATCH" }
 </summary>
 Returns the relative position of an item in a range that matches a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__OFFSET__(cell_reference, offset_rows, offset_columns, height, width)</code> {: #offset }
+#### <code>__OFFSET__(cell_reference, offset_rows, offset_columns, height, width)</code> {: #offset data-toc-label="OFFSET" }
 </summary>
 Returns a range reference shifted a specified number of rows and columns from a starting cell reference.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__ROW__(cell_reference)</code> {: #row }
+#### <code>__ROW__(cell_reference)</code> {: #row data-toc-label="ROW" }
 </summary>
 Returns the row number of a specified cell.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__ROWS__(range)</code> {: #rows }
+#### <code>__ROWS__(range)</code> {: #rows data-toc-label="ROWS" }
 </summary>
 Returns the number of rows in a specified array or range.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details markdown><summary >
-#### <code>__SELF_HYPERLINK__(label=None, page=None, **kwargs)</code> {: #self_hyperlink }
+#### <code>__SELF_HYPERLINK__(label=None, page=None, **kwargs)</code> {: #self_hyperlink data-toc-label="SELF_HYPERLINK" }
 </summary>
 Creates a link to the current document.  All parameters are optional.
 
@@ -1895,7 +1895,7 @@ TypeError: unexpected keyword argument 'Linky_Link' (not of form LinkKey_NAME)
 
 </details>
 <details markdown><summary >
-#### <code>__VLOOKUP__(table, **field_value_pairs)</code> {: #vlookup }
+#### <code>__VLOOKUP__(table, **field_value_pairs)</code> {: #vlookup data-toc-label="VLOOKUP" }
 </summary>
 Vertical lookup. Searches the given table for a record matching the given `field=value`
 arguments. If multiple records match, returns one of them. If none match, returns the special
@@ -1918,7 +1918,7 @@ VLOOKUP(People, First_Name="Lewis", Last_Name="Carroll").Age
 </details>
 ### Math
 <details markdown><summary >
-#### <code>__ABS__(value)</code> {: #abs }
+#### <code>__ABS__(value)</code> {: #abs data-toc-label="ABS" }
 </summary>
 Returns the absolute value of a number.
 
@@ -1940,7 +1940,7 @@ Returns the absolute value of a number.
 
 </details>
 <details markdown><summary >
-#### <code>__ACOS__(value)</code> {: #acos }
+#### <code>__ACOS__(value)</code> {: #acos data-toc-label="ACOS" }
 </summary>
 Returns the inverse cosine of a value, in radians.
 
@@ -1957,7 +1957,7 @@ Returns the inverse cosine of a value, in radians.
 
 </details>
 <details markdown><summary >
-#### <code>__ACOSH__(value)</code> {: #acosh }
+#### <code>__ACOSH__(value)</code> {: #acosh data-toc-label="ACOSH" }
 </summary>
 Returns the inverse hyperbolic cosine of a number.
 
@@ -1974,7 +1974,7 @@ Returns the inverse hyperbolic cosine of a number.
 
 </details>
 <details markdown><summary >
-#### <code>__ARABIC__(roman_numeral)</code> {: #arabic }
+#### <code>__ARABIC__(roman_numeral)</code> {: #arabic data-toc-label="ARABIC" }
 </summary>
 Computes the value of a Roman numeral.
 
@@ -1991,7 +1991,7 @@ Computes the value of a Roman numeral.
 
 </details>
 <details markdown><summary >
-#### <code>__ASIN__(value)</code> {: #asin }
+#### <code>__ASIN__(value)</code> {: #asin data-toc-label="ASIN" }
 </summary>
 Returns the inverse sine of a value, in radians.
 
@@ -2013,7 +2013,7 @@ Returns the inverse sine of a value, in radians.
 
 </details>
 <details markdown><summary >
-#### <code>__ASINH__(value)</code> {: #asinh }
+#### <code>__ASINH__(value)</code> {: #asinh data-toc-label="ASINH" }
 </summary>
 Returns the inverse hyperbolic sine of a number.
 
@@ -2030,7 +2030,7 @@ Returns the inverse hyperbolic sine of a number.
 
 </details>
 <details markdown><summary >
-#### <code>__ATAN__(value)</code> {: #atan }
+#### <code>__ATAN__(value)</code> {: #atan data-toc-label="ATAN" }
 </summary>
 Returns the inverse tangent of a value, in radians.
 
@@ -2052,7 +2052,7 @@ Returns the inverse tangent of a value, in radians.
 
 </details>
 <details markdown><summary >
-#### <code>__ATAN2__(x, y)</code> {: #atan2 }
+#### <code>__ATAN2__(x, y)</code> {: #atan2 data-toc-label="ATAN2" }
 </summary>
 Returns the angle between the x-axis and a line segment from the origin (0,0) to specified
 coordinate pair (`x`,`y`), in radians.
@@ -2085,7 +2085,7 @@ coordinate pair (`x`,`y`), in radians.
 
 </details>
 <details markdown><summary >
-#### <code>__ATANH__(value)</code> {: #atanh }
+#### <code>__ATANH__(value)</code> {: #atanh data-toc-label="ATANH" }
 </summary>
 Returns the inverse hyperbolic tangent of a number.
 
@@ -2102,7 +2102,7 @@ Returns the inverse hyperbolic tangent of a number.
 
 </details>
 <details markdown><summary >
-#### <code>__CEILING__(value, factor=1)</code> {: #ceiling }
+#### <code>__CEILING__(value, factor=1)</code> {: #ceiling data-toc-label="CEILING" }
 </summary>
 Rounds a number up to the nearest multiple of factor, or the nearest integer if the factor is
 omitted or 1.
@@ -2135,7 +2135,7 @@ omitted or 1.
 
 </details>
 <details markdown><summary >
-#### <code>__COMBIN__(n, k)</code> {: #combin }
+#### <code>__COMBIN__(n, k)</code> {: #combin data-toc-label="COMBIN" }
 </summary>
 Returns the number of ways to choose some number of objects from a pool of a given size of
 objects.
@@ -2158,7 +2158,7 @@ objects.
 
 </details>
 <details markdown><summary >
-#### <code>__COS__(angle)</code> {: #cos }
+#### <code>__COS__(angle)</code> {: #cos data-toc-label="COS" }
 </summary>
 Returns the cosine of an angle provided in radians.
 
@@ -2180,7 +2180,7 @@ Returns the cosine of an angle provided in radians.
 
 </details>
 <details markdown><summary >
-#### <code>__COSH__(value)</code> {: #cosh }
+#### <code>__COSH__(value)</code> {: #cosh data-toc-label="COSH" }
 </summary>
 Returns the hyperbolic cosine of any real number.
 
@@ -2197,7 +2197,7 @@ Returns the hyperbolic cosine of any real number.
 
 </details>
 <details markdown><summary >
-#### <code>__DEGREES__(angle)</code> {: #degrees }
+#### <code>__DEGREES__(angle)</code> {: #degrees data-toc-label="DEGREES" }
 </summary>
 Converts an angle value in radians to degrees.
 
@@ -2214,7 +2214,7 @@ Converts an angle value in radians to degrees.
 
 </details>
 <details markdown><summary >
-#### <code>__EVEN__(value)</code> {: #even }
+#### <code>__EVEN__(value)</code> {: #even data-toc-label="EVEN" }
 </summary>
 Rounds a number up to the nearest even integer, rounding away from zero.
 
@@ -2241,7 +2241,7 @@ Rounds a number up to the nearest even integer, rounding away from zero.
 
 </details>
 <details markdown><summary >
-#### <code>__EXP__(exponent)</code> {: #exp }
+#### <code>__EXP__(exponent)</code> {: #exp data-toc-label="EXP" }
 </summary>
 Returns Euler's number, e (~2.718) raised to a power.
 
@@ -2258,7 +2258,7 @@ Returns Euler's number, e (~2.718) raised to a power.
 
 </details>
 <details markdown><summary >
-#### <code>__FACT__(value)</code> {: #fact }
+#### <code>__FACT__(value)</code> {: #fact data-toc-label="FACT" }
 </summary>
 Returns the factorial of a number.
 
@@ -2292,7 +2292,7 @@ ValueError: factorial() not defined for negative values
 
 </details>
 <details markdown><summary >
-#### <code>__FACTDOUBLE__(value)</code> {: #factdouble }
+#### <code>__FACTDOUBLE__(value)</code> {: #factdouble data-toc-label="FACTDOUBLE" }
 </summary>
 Returns the "double factorial" of a number.
 
@@ -2319,7 +2319,7 @@ Returns the "double factorial" of a number.
 
 </details>
 <details markdown><summary >
-#### <code>__FLOOR__(value, factor=1)</code> {: #floor }
+#### <code>__FLOOR__(value, factor=1)</code> {: #floor data-toc-label="FLOOR" }
 </summary>
 Rounds a number down to the nearest integer multiple of specified significance.
 
@@ -2353,7 +2353,7 @@ ValueError: factor argument invalid
 
 </details>
 <details markdown><summary >
-#### <code>__GCD__(value1, *more_values)</code> {: #gcd }
+#### <code>__GCD__(value1, *more_values)</code> {: #gcd data-toc-label="GCD" }
 </summary>
 Returns the greatest common divisor of one or more integers.
 
@@ -2395,7 +2395,7 @@ Returns the greatest common divisor of one or more integers.
 
 </details>
 <details markdown><summary >
-#### <code>__INT__(value)</code> {: #int }
+#### <code>__INT__(value)</code> {: #int data-toc-label="INT" }
 </summary>
 Rounds a number down to the nearest integer that is less than or equal to it.
 
@@ -2417,7 +2417,7 @@ Rounds a number down to the nearest integer that is less than or equal to it.
 
 </details>
 <details markdown><summary >
-#### <code>__LCM__(value1, *more_values)</code> {: #lcm }
+#### <code>__LCM__(value1, *more_values)</code> {: #lcm data-toc-label="LCM" }
 </summary>
 Returns the least common multiple of one or more integers.
 
@@ -2459,7 +2459,7 @@ Returns the least common multiple of one or more integers.
 
 </details>
 <details markdown><summary >
-#### <code>__LN__(value)</code> {: #ln }
+#### <code>__LN__(value)</code> {: #ln data-toc-label="LN" }
 </summary>
 Returns the the logarithm of a number, base e (Euler's number).
 
@@ -2481,7 +2481,7 @@ Returns the the logarithm of a number, base e (Euler's number).
 
 </details>
 <details markdown><summary >
-#### <code>__LOG__(value, base=10)</code> {: #log }
+#### <code>__LOG__(value, base=10)</code> {: #log data-toc-label="LOG" }
 </summary>
 Returns the the logarithm of a number given a base.
 
@@ -2503,7 +2503,7 @@ Returns the the logarithm of a number given a base.
 
 </details>
 <details markdown><summary >
-#### <code>__LOG10__(value)</code> {: #log10 }
+#### <code>__LOG10__(value)</code> {: #log10 data-toc-label="LOG10" }
 </summary>
 Returns the the logarithm of a number, base 10.
 
@@ -2530,7 +2530,7 @@ Returns the the logarithm of a number, base 10.
 
 </details>
 <details markdown><summary >
-#### <code>__MOD__(dividend, divisor)</code> {: #mod }
+#### <code>__MOD__(dividend, divisor)</code> {: #mod data-toc-label="MOD" }
 </summary>
 Returns the result of the modulo operator, the remainder after a division operation.
 
@@ -2557,7 +2557,7 @@ Returns the result of the modulo operator, the remainder after a division operat
 
 </details>
 <details markdown><summary >
-#### <code>__MROUND__(value, factor)</code> {: #mround }
+#### <code>__MROUND__(value, factor)</code> {: #mround data-toc-label="MROUND" }
 </summary>
 Rounds one number to the nearest integer multiple of another.
 
@@ -2586,7 +2586,7 @@ ValueError: factor argument invalid
 
 </details>
 <details markdown><summary >
-#### <code>__MULTINOMIAL__(value1, *more_values)</code> {: #multinomial }
+#### <code>__MULTINOMIAL__(value1, *more_values)</code> {: #multinomial data-toc-label="MULTINOMIAL" }
 </summary>
 Returns the factorial of the sum of values divided by the product of the values' factorials.
 
@@ -2613,7 +2613,7 @@ Returns the factorial of the sum of values divided by the product of the values'
 
 </details>
 <details markdown><summary >
-#### <code>__NUM__(value)</code> {: #num }
+#### <code>__NUM__(value)</code> {: #num data-toc-label="NUM" }
 </summary>
 For a Python floating-point value that's actually an integer, returns a Python integer type.
 Otherwise, returns the value unchanged. This is helpful sometimes when a value comes from a
@@ -2642,7 +2642,7 @@ Numeric Grist column (represented as floats), but when int values are actually e
 
 </details>
 <details markdown><summary >
-#### <code>__ODD__(value)</code> {: #odd }
+#### <code>__ODD__(value)</code> {: #odd data-toc-label="ODD" }
 </summary>
 Rounds a number up to the nearest odd integer.
 
@@ -2674,7 +2674,7 @@ Rounds a number up to the nearest odd integer.
 
 </details>
 <details markdown><summary >
-#### <code>__PI__()</code> {: #pi }
+#### <code>__PI__()</code> {: #pi data-toc-label="PI" }
 </summary>
 Returns the value of Pi to 14 decimal places.
 
@@ -2696,7 +2696,7 @@ Returns the value of Pi to 14 decimal places.
 
 </details>
 <details markdown><summary >
-#### <code>__POWER__(base, exponent)</code> {: #power }
+#### <code>__POWER__(base, exponent)</code> {: #power data-toc-label="POWER" }
 </summary>
 Returns a number raised to a power.
 
@@ -2718,7 +2718,7 @@ Returns a number raised to a power.
 
 </details>
 <details markdown><summary >
-#### <code>__PRODUCT__(factor1, *more_factors)</code> {: #product }
+#### <code>__PRODUCT__(factor1, *more_factors)</code> {: #product data-toc-label="PRODUCT" }
 </summary>
 Returns the result of multiplying a series of numbers together. Each argument may be a number or
 an array.
@@ -2740,7 +2740,7 @@ an array.
 ```
 </details>
 <details markdown><summary >
-#### <code>__QUOTIENT__(dividend, divisor)</code> {: #quotient }
+#### <code>__QUOTIENT__(dividend, divisor)</code> {: #quotient data-toc-label="QUOTIENT" }
 </summary>
 Returns one number divided by another, without the remainder.
 
@@ -2762,7 +2762,7 @@ Returns one number divided by another, without the remainder.
 
 </details>
 <details markdown><summary >
-#### <code>__RADIANS__(angle)</code> {: #radians }
+#### <code>__RADIANS__(angle)</code> {: #radians data-toc-label="RADIANS" }
 </summary>
 Converts an angle value in degrees to radians.
 
@@ -2774,17 +2774,17 @@ Converts an angle value in degrees to radians.
 
 </details>
 <details markdown><summary >
-#### <code>__RAND__()</code> {: #rand }
+#### <code>__RAND__()</code> {: #rand data-toc-label="RAND" }
 </summary>
 Returns a random number between 0 inclusive and 1 exclusive.
 </details>
 <details markdown><summary >
-#### <code>__RANDBETWEEN__(low, high)</code> {: #randbetween }
+#### <code>__RANDBETWEEN__(low, high)</code> {: #randbetween data-toc-label="RANDBETWEEN" }
 </summary>
 Returns a uniformly random integer between two values, inclusive.
 </details>
 <details markdown><summary >
-#### <code>__ROMAN__(number, form_unused=None)</code> {: #roman }
+#### <code>__ROMAN__(number, form_unused=None)</code> {: #roman data-toc-label="ROMAN" }
 </summary>
 Formats a number in Roman numerals. The second argument is ignored in this implementation.
 
@@ -2811,7 +2811,7 @@ Formats a number in Roman numerals. The second argument is ignored in this imple
 
 </details>
 <details markdown><summary >
-#### <code>__ROUND__(value, places=0)</code> {: #round }
+#### <code>__ROUND__(value, places=0)</code> {: #round data-toc-label="ROUND" }
 </summary>
 Rounds a number to a certain number of decimal places,
 by default to the nearest whole number if the number of places is not given.
@@ -2877,7 +2877,7 @@ in the case of a tie, i.e. when the last digit is 5.
 
 </details>
 <details markdown><summary >
-#### <code>__ROUNDDOWN__(value, places=0)</code> {: #rounddown }
+#### <code>__ROUNDDOWN__(value, places=0)</code> {: #rounddown data-toc-label="ROUNDDOWN" }
 </summary>
 Rounds a number to a certain number of decimal places, always rounding down towards zero.
 
@@ -2909,7 +2909,7 @@ Rounds a number to a certain number of decimal places, always rounding down towa
 
 </details>
 <details markdown><summary >
-#### <code>__ROUNDUP__(value, places=0)</code> {: #roundup }
+#### <code>__ROUNDUP__(value, places=0)</code> {: #roundup data-toc-label="ROUNDUP" }
 </summary>
 Rounds a number to a certain number of decimal places, always rounding up away from zero.
 
@@ -2941,7 +2941,7 @@ Rounds a number to a certain number of decimal places, always rounding up away f
 
 </details>
 <details markdown><summary >
-#### <code>__SERIESSUM__(x, n, m, a)</code> {: #seriessum }
+#### <code>__SERIESSUM__(x, n, m, a)</code> {: #seriessum data-toc-label="SERIESSUM" }
 </summary>
 Given parameters x, n, m, and a, returns the power series sum a_1*x^n + a_2*x^(n+m)
 + ... + a_i*x^(n+(i-1)m), where i is the number of entries in range `a`.
@@ -2969,7 +2969,7 @@ Given parameters x, n, m, and a, returns the power series sum a_1*x^n + a_2*x^(n
 
 </details>
 <details markdown><summary >
-#### <code>__SIGN__(value)</code> {: #sign }
+#### <code>__SIGN__(value)</code> {: #sign data-toc-label="SIGN" }
 </summary>
 Given an input number, returns `-1` if it is negative, `1` if positive, and `0` if it is zero.
 
@@ -2991,7 +2991,7 @@ Given an input number, returns `-1` if it is negative, `1` if positive, and `0` 
 
 </details>
 <details markdown><summary >
-#### <code>__SIN__(angle)</code> {: #sin }
+#### <code>__SIN__(angle)</code> {: #sin data-toc-label="SIN" }
 </summary>
 Returns the sine of an angle provided in radians.
 
@@ -3018,7 +3018,7 @@ Returns the sine of an angle provided in radians.
 
 </details>
 <details markdown><summary >
-#### <code>__SINH__(value)</code> {: #sinh }
+#### <code>__SINH__(value)</code> {: #sinh data-toc-label="SINH" }
 </summary>
 Returns the hyperbolic sine of any real number.
 
@@ -3030,7 +3030,7 @@ Returns the hyperbolic sine of any real number.
 
 </details>
 <details markdown><summary >
-#### <code>__SQRT__(value)</code> {: #sqrt }
+#### <code>__SQRT__(value)</code> {: #sqrt data-toc-label="SQRT" }
 </summary>
 Returns the positive square root of a positive number.
 
@@ -3054,7 +3054,7 @@ ValueError: math domain error
 
 </details>
 <details markdown><summary >
-#### <code>__SQRTPI__(value)</code> {: #sqrtpi }
+#### <code>__SQRTPI__(value)</code> {: #sqrtpi data-toc-label="SQRTPI" }
 </summary>
 Returns the positive square root of the product of Pi and the given positive number.
 
@@ -3071,14 +3071,14 @@ Returns the positive square root of the product of Pi and the given positive num
 
 </details>
 <details>
-#### <code>__SUBTOTAL__(function_code, range1, range2)</code> {: #subtotal }
+#### <code>__SUBTOTAL__(function_code, range1, range2)</code> {: #subtotal data-toc-label="SUBTOTAL" }
 </summary>
 Returns a subtotal for a vertical range of cells using a specified aggregation function.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details markdown><summary >
-#### <code>__SUM__(value1, *more_values)</code> {: #sum }
+#### <code>__SUM__(value1, *more_values)</code> {: #sum data-toc-label="SUM" }
 </summary>
 Returns the sum of a series of numbers. Each argument may be a number or an array.
 Non-numeric values are ignored.
@@ -3100,21 +3100,21 @@ Non-numeric values are ignored.
 ```
 </details>
 <details>
-#### <code>__SUMIF__(records, criterion, sum_range)</code> {: #sumif }
+#### <code>__SUMIF__(records, criterion, sum_range)</code> {: #sumif data-toc-label="SUMIF" }
 </summary>
 Returns a conditional sum across a range.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__SUMIFS__(sum_range, criteria_range1, criterion1, *args)</code> {: #sumifs }
+#### <code>__SUMIFS__(sum_range, criteria_range1, criterion1, *args)</code> {: #sumifs data-toc-label="SUMIFS" }
 </summary>
 Returns the sum of a range depending on multiple criteria.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details markdown><summary >
-#### <code>__SUMPRODUCT__(array1, *more_arrays)</code> {: #sumproduct }
+#### <code>__SUMPRODUCT__(array1, *more_arrays)</code> {: #sumproduct data-toc-label="SUMPRODUCT" }
 </summary>
 Multiplies corresponding components in two equally-sized arrays,
 and returns the sum of those products.
@@ -3142,14 +3142,14 @@ and returns the sum of those products.
 
 </details>
 <details>
-#### <code>__SUMSQ__(value1, value2)</code> {: #sumsq }
+#### <code>__SUMSQ__(value1, value2)</code> {: #sumsq data-toc-label="SUMSQ" }
 </summary>
 Returns the sum of the squares of a series of numbers and/or cells.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details markdown><summary >
-#### <code>__TAN__(angle)</code> {: #tan }
+#### <code>__TAN__(angle)</code> {: #tan data-toc-label="TAN" }
 </summary>
 Returns the tangent of an angle provided in radians.
 
@@ -3171,7 +3171,7 @@ Returns the tangent of an angle provided in radians.
 
 </details>
 <details markdown><summary >
-#### <code>__TANH__(value)</code> {: #tanh }
+#### <code>__TANH__(value)</code> {: #tanh data-toc-label="TANH" }
 </summary>
 Returns the hyperbolic tangent of any real number.
 
@@ -3193,7 +3193,7 @@ Returns the hyperbolic tangent of any real number.
 
 </details>
 <details markdown><summary >
-#### <code>__TRUNC__(value, places=0)</code> {: #trunc }
+#### <code>__TRUNC__(value, places=0)</code> {: #trunc data-toc-label="TRUNC" }
 </summary>
 Truncates a number to a certain number of significant digits by omitting less significant
 digits.
@@ -3216,7 +3216,7 @@ digits.
 
 </details>
 <details markdown><summary >
-#### <code>__UUID__()</code> {: #uuid }
+#### <code>__UUID__()</code> {: #uuid data-toc-label="UUID" }
 </summary>
 Generate a random UUID-formatted string identifier.
 
@@ -3228,7 +3228,7 @@ UUID() each time.
 </details>
 ### Schedule
 <details markdown><summary >
-#### <code>__SCHEDULE__(schedule, start=None, count=10, end=None)</code> {: #schedule }
+#### <code>__SCHEDULE__(schedule, start=None, count=10, end=None)</code> {: #schedule data-toc-label="SCHEDULE" }
 </summary>
 Returns the list of `datetime` objects generated according to the `schedule` string. Starts at
 `start`, which defaults to NOW(). Generates at most `count` results (10 by default). If `end` is
@@ -3351,14 +3351,14 @@ The time zone of `start` determines the time zone of the generated times.
 </details>
 ### Stats
 <details>
-#### <code>__AVEDEV__(value1, value2)</code> {: #avedev }
+#### <code>__AVEDEV__(value1, value2)</code> {: #avedev data-toc-label="AVEDEV" }
 </summary>
 Calculates the average of the magnitudes of deviations of data from a dataset's mean.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details markdown><summary >
-#### <code>__AVERAGE__(value, *more_values)</code> {: #average }
+#### <code>__AVERAGE__(value, *more_values)</code> {: #average data-toc-label="AVERAGE" }
 </summary>
 Returns the numerical average value in a dataset, ignoring non-numerical values.
 
@@ -3390,7 +3390,7 @@ ZeroDivisionError: float division by zero
 
 </details>
 <details markdown><summary >
-#### <code>__AVERAGEA__(value, *more_values)</code> {: #averagea }
+#### <code>__AVERAGEA__(value, *more_values)</code> {: #averagea data-toc-label="AVERAGEA" }
 </summary>
 Returns the numerical average value in a dataset, counting non-numerical values as 0.
 
@@ -3421,21 +3421,21 @@ False as 0.
 
 </details>
 <details>
-#### <code>__AVERAGEIF__(criteria_range, criterion, average_range=None)</code> {: #averageif }
+#### <code>__AVERAGEIF__(criteria_range, criterion, average_range=None)</code> {: #averageif data-toc-label="AVERAGEIF" }
 </summary>
 Returns the average of a range depending on criteria.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__AVERAGEIFS__(average_range, criteria_range1, criterion1, *args)</code> {: #averageifs }
+#### <code>__AVERAGEIFS__(average_range, criteria_range1, criterion1, *args)</code> {: #averageifs data-toc-label="AVERAGEIFS" }
 </summary>
 Returns the average of a range depending on multiple criteria.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details markdown><summary >
-#### <code>__AVERAGE_WEIGHTED__(pairs)</code> {: #average_weighted }
+#### <code>__AVERAGE_WEIGHTED__(pairs)</code> {: #average_weighted data-toc-label="AVERAGE_WEIGHTED" }
 </summary>
 Given a list of (value, weight) pairs, finds the average of the values weighted by the
 corresponding weights. Ignores any pairs with a non-numerical value or weight.
@@ -3461,7 +3461,7 @@ list of pairs.
 
 </details>
 <details>
-#### <code>__BINOMDIST__(num_successes, num_trials, prob_success, cumulative)</code> {: #binomdist }
+#### <code>__BINOMDIST__(num_successes, num_trials, prob_success, cumulative)</code> {: #binomdist data-toc-label="BINOMDIST" }
 </summary>
 Calculates the probability of drawing a certain number of successes (or a maximum number of
 successes) in a certain number of tries given a population of a certain size containing a
@@ -3470,21 +3470,21 @@ certain number of successes, with replacement of draws.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__CONFIDENCE__(alpha, standard_deviation, pop_size)</code> {: #confidence }
+#### <code>__CONFIDENCE__(alpha, standard_deviation, pop_size)</code> {: #confidence data-toc-label="CONFIDENCE" }
 </summary>
 Calculates the width of half the confidence interval for a normal distribution.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__CORREL__(data_y, data_x)</code> {: #correl }
+#### <code>__CORREL__(data_y, data_x)</code> {: #correl data-toc-label="CORREL" }
 </summary>
 Calculates r, the Pearson product-moment correlation coefficient of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details markdown><summary >
-#### <code>__COUNT__(value, *more_values)</code> {: #count }
+#### <code>__COUNT__(value, *more_values)</code> {: #count data-toc-label="COUNT" }
 </summary>
 Returns the count of numerical and date/datetime values in a dataset,
 ignoring other types of values.
@@ -3520,7 +3520,7 @@ and blank values, and text representations of numbers, are ignored.
 
 </details>
 <details markdown><summary >
-#### <code>__COUNTA__(value, *more_values)</code> {: #counta }
+#### <code>__COUNTA__(value, *more_values)</code> {: #counta data-toc-label="COUNTA" }
 </summary>
 Returns the count of all values in a dataset, including non-numerical values.
 
@@ -3549,35 +3549,35 @@ Each argument may be a value or an array.
 
 </details>
 <details>
-#### <code>__COVAR__(data_y, data_x)</code> {: #covar }
+#### <code>__COVAR__(data_y, data_x)</code> {: #covar data-toc-label="COVAR" }
 </summary>
 Calculates the covariance of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__CRITBINOM__(num_trials, prob_success, target_prob)</code> {: #critbinom }
+#### <code>__CRITBINOM__(num_trials, prob_success, target_prob)</code> {: #critbinom data-toc-label="CRITBINOM" }
 </summary>
 Calculates the smallest value for which the cumulative binomial distribution is greater than or equal to a specified criteria.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__DEVSQ__(value1, value2)</code> {: #devsq }
+#### <code>__DEVSQ__(value1, value2)</code> {: #devsq data-toc-label="DEVSQ" }
 </summary>
 Calculates the sum of squares of deviations based on a sample.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__EXPONDIST__(x, lambda_, cumulative)</code> {: #expondist }
+#### <code>__EXPONDIST__(x, lambda_, cumulative)</code> {: #expondist data-toc-label="EXPONDIST" }
 </summary>
 Returns the value of the exponential distribution function with a specified lambda at a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__FDIST__(x, degrees_freedom1, degrees_freedom2)</code> {: #fdist }
+#### <code>__FDIST__(x, degrees_freedom1, degrees_freedom2)</code> {: #fdist data-toc-label="FDIST" }
 </summary>
 Calculates the right-tailed F probability distribution (degree of diversity) for two data sets
 with given input x. Alternately called Fisher-Snedecor distribution or Snedecor's F
@@ -3586,28 +3586,28 @@ distribution.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__FISHER__(value)</code> {: #fisher }
+#### <code>__FISHER__(value)</code> {: #fisher data-toc-label="FISHER" }
 </summary>
 Returns the Fisher transformation of a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__FISHERINV__(value)</code> {: #fisherinv }
+#### <code>__FISHERINV__(value)</code> {: #fisherinv data-toc-label="FISHERINV" }
 </summary>
 Returns the inverse Fisher transformation of a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__FORECAST__(x, data_y, data_x)</code> {: #forecast }
+#### <code>__FORECAST__(x, data_y, data_x)</code> {: #forecast data-toc-label="FORECAST" }
 </summary>
 Calculates the expected y-value for a specified x based on a linear regression of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__F_DIST__(x, degrees_freedom1, degrees_freedom2, cumulative)</code> {: #f_dist }
+#### <code>__F_DIST__(x, degrees_freedom1, degrees_freedom2, cumulative)</code> {: #f_dist data-toc-label="F_DIST" }
 </summary>
 Calculates the left-tailed F probability distribution (degree of diversity) for two data sets
 with given input x. Alternately called Fisher-Snedecor distribution or Snedecor's F
@@ -3616,7 +3616,7 @@ distribution.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__F_DIST_RT__(x, degrees_freedom1, degrees_freedom2)</code> {: #f_dist_rt }
+#### <code>__F_DIST_RT__(x, degrees_freedom1, degrees_freedom2)</code> {: #f_dist_rt data-toc-label="F_DIST_RT" }
 </summary>
 Calculates the right-tailed F probability distribution (degree of diversity) for two data sets
 with given input x. Alternately called Fisher-Snedecor distribution or Snedecor's F
@@ -3625,63 +3625,63 @@ distribution.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__GEOMEAN__(value1, value2)</code> {: #geomean }
+#### <code>__GEOMEAN__(value1, value2)</code> {: #geomean data-toc-label="GEOMEAN" }
 </summary>
 Calculates the geometric mean of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__HARMEAN__(value1, value2)</code> {: #harmean }
+#### <code>__HARMEAN__(value1, value2)</code> {: #harmean data-toc-label="HARMEAN" }
 </summary>
 Calculates the harmonic mean of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__HYPGEOMDIST__(num_successes, num_draws, successes_in_pop, pop_size)</code> {: #hypgeomdist }
+#### <code>__HYPGEOMDIST__(num_successes, num_draws, successes_in_pop, pop_size)</code> {: #hypgeomdist data-toc-label="HYPGEOMDIST" }
 </summary>
 Calculates the probability of drawing a certain number of successes in a certain number of tries given a population of a certain size containing a certain number of successes, without replacement of draws.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__INTERCEPT__(data_y, data_x)</code> {: #intercept }
+#### <code>__INTERCEPT__(data_y, data_x)</code> {: #intercept data-toc-label="INTERCEPT" }
 </summary>
 Calculates the y-value at which the line resulting from linear regression of a dataset will intersect the y-axis (x=0).
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__KURT__(value1, value2)</code> {: #kurt }
+#### <code>__KURT__(value1, value2)</code> {: #kurt data-toc-label="KURT" }
 </summary>
 Calculates the kurtosis of a dataset, which describes the shape, and in particular the "peakedness" of that dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__LARGE__(data, n)</code> {: #large }
+#### <code>__LARGE__(data, n)</code> {: #large data-toc-label="LARGE" }
 </summary>
 Returns the nth largest element from a data set, where n is user-defined.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__LOGINV__(x, mean, standard_deviation)</code> {: #loginv }
+#### <code>__LOGINV__(x, mean, standard_deviation)</code> {: #loginv data-toc-label="LOGINV" }
 </summary>
 Returns the value of the inverse log-normal cumulative distribution with given mean and standard deviation at a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__LOGNORMDIST__(x, mean, standard_deviation)</code> {: #lognormdist }
+#### <code>__LOGNORMDIST__(x, mean, standard_deviation)</code> {: #lognormdist data-toc-label="LOGNORMDIST" }
 </summary>
 Returns the value of the log-normal cumulative distribution with given mean and standard deviation at a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details markdown><summary >
-#### <code>__MAX__(value, *more_values)</code> {: #max }
+#### <code>__MAX__(value, *more_values)</code> {: #max data-toc-label="MAX" }
 </summary>
 Returns the maximum value in a dataset, ignoring values other than numbers and dates/datetimes.
 
@@ -3732,7 +3732,7 @@ datetime.date(2015, 1, 2)
 
 </details>
 <details markdown><summary >
-#### <code>__MAXA__(value, *more_values)</code> {: #maxa }
+#### <code>__MAXA__(value, *more_values)</code> {: #maxa data-toc-label="MAXA" }
 </summary>
 Returns the maximum numeric value in a dataset.
 
@@ -3768,7 +3768,7 @@ False as 0. Returns 0 if the arguments contain no numbers.
 
 </details>
 <details markdown><summary >
-#### <code>__MEDIAN__(value, *more_values)</code> {: #median }
+#### <code>__MEDIAN__(value, *more_values)</code> {: #median data-toc-label="MEDIAN" }
 </summary>
 Returns the median value in a numeric dataset, ignoring non-numerical values.
 
@@ -3811,7 +3811,7 @@ ValueError: MEDIAN requires at least one number
 
 </details>
 <details markdown><summary >
-#### <code>__MIN__(value, *more_values)</code> {: #min }
+#### <code>__MIN__(value, *more_values)</code> {: #min data-toc-label="MIN" }
 </summary>
 Returns the minimum value in a dataset, ignoring values other than numbers and dates/datetimes.
 
@@ -3862,7 +3862,7 @@ datetime.datetime(2015, 1, 1, 12, 34, 56)
 
 </details>
 <details markdown><summary >
-#### <code>__MINA__(value, *more_values)</code> {: #mina }
+#### <code>__MINA__(value, *more_values)</code> {: #mina data-toc-label="MINA" }
 </summary>
 Returns the minimum numeric value in a dataset.
 
@@ -3898,21 +3898,21 @@ False as 0. Returns 0 if the arguments contain no numbers.
 
 </details>
 <details>
-#### <code>__MODE__(value1, value2)</code> {: #mode }
+#### <code>__MODE__(value1, value2)</code> {: #mode data-toc-label="MODE" }
 </summary>
 Returns the most commonly occurring value in a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__NEGBINOMDIST__(num_failures, num_successes, prob_success)</code> {: #negbinomdist }
+#### <code>__NEGBINOMDIST__(num_failures, num_successes, prob_success)</code> {: #negbinomdist data-toc-label="NEGBINOMDIST" }
 </summary>
 Calculates the probability of drawing a certain number of failures before a certain number of successes given a probability of success in independent trials.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__NORMDIST__(x, mean, standard_deviation, cumulative)</code> {: #normdist }
+#### <code>__NORMDIST__(x, mean, standard_deviation, cumulative)</code> {: #normdist data-toc-label="NORMDIST" }
 </summary>
 Returns the value of the normal distribution function (or normal cumulative distribution
 function) for a specified value, mean, and standard deviation.
@@ -3920,70 +3920,70 @@ function) for a specified value, mean, and standard deviation.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__NORMINV__(x, mean, standard_deviation)</code> {: #norminv }
+#### <code>__NORMINV__(x, mean, standard_deviation)</code> {: #norminv data-toc-label="NORMINV" }
 </summary>
 Returns the value of the inverse normal distribution function for a specified value, mean, and standard deviation.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__NORMSDIST__(x)</code> {: #normsdist }
+#### <code>__NORMSDIST__(x)</code> {: #normsdist data-toc-label="NORMSDIST" }
 </summary>
 Returns the value of the standard normal cumulative distribution function for a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__NORMSINV__(x)</code> {: #normsinv }
+#### <code>__NORMSINV__(x)</code> {: #normsinv data-toc-label="NORMSINV" }
 </summary>
 Returns the value of the inverse standard normal distribution function for a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__PEARSON__(data_y, data_x)</code> {: #pearson }
+#### <code>__PEARSON__(data_y, data_x)</code> {: #pearson data-toc-label="PEARSON" }
 </summary>
 Calculates r, the Pearson product-moment correlation coefficient of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__PERCENTILE__(data, percentile)</code> {: #percentile }
+#### <code>__PERCENTILE__(data, percentile)</code> {: #percentile data-toc-label="PERCENTILE" }
 </summary>
 Returns the value at a given percentile of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__PERCENTRANK__(data, value, significant_digits=None)</code> {: #percentrank }
+#### <code>__PERCENTRANK__(data, value, significant_digits=None)</code> {: #percentrank data-toc-label="PERCENTRANK" }
 </summary>
 Returns the percentage rank (percentile) of a specified value in a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__PERCENTRANK_EXC__(data, value, significant_digits=None)</code> {: #percentrank_exc }
+#### <code>__PERCENTRANK_EXC__(data, value, significant_digits=None)</code> {: #percentrank_exc data-toc-label="PERCENTRANK_EXC" }
 </summary>
 Returns the percentage rank (percentile) from 0 to 1 exclusive of a specified value in a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__PERCENTRANK_INC__(data, value, significant_digits=None)</code> {: #percentrank_inc }
+#### <code>__PERCENTRANK_INC__(data, value, significant_digits=None)</code> {: #percentrank_inc data-toc-label="PERCENTRANK_INC" }
 </summary>
 Returns the percentage rank (percentile) from 0 to 1 inclusive of a specified value in a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__PERMUT__(n, k)</code> {: #permut }
+#### <code>__PERMUT__(n, k)</code> {: #permut data-toc-label="PERMUT" }
 </summary>
 Returns the number of ways to choose some number of objects from a pool of a given size of objects, considering order.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__POISSON__(x, mean, cumulative)</code> {: #poisson }
+#### <code>__POISSON__(x, mean, cumulative)</code> {: #poisson data-toc-label="POISSON" }
 </summary>
 Returns the value of the Poisson distribution function (or Poisson cumulative distribution
 function) for a specified value and mean.
@@ -3991,70 +3991,70 @@ function) for a specified value and mean.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__PROB__(data, probabilities, low_limit, high_limit=None)</code> {: #prob }
+#### <code>__PROB__(data, probabilities, low_limit, high_limit=None)</code> {: #prob data-toc-label="PROB" }
 </summary>
 Given a set of values and corresponding probabilities, calculates the probability that a value chosen at random falls between two limits.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__QUARTILE__(data, quartile_number)</code> {: #quartile }
+#### <code>__QUARTILE__(data, quartile_number)</code> {: #quartile data-toc-label="QUARTILE" }
 </summary>
 Returns a value nearest to a specified quartile of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__RANK_AVG__(value, data, is_ascending=None)</code> {: #rank_avg }
+#### <code>__RANK_AVG__(value, data, is_ascending=None)</code> {: #rank_avg data-toc-label="RANK_AVG" }
 </summary>
 Returns the rank of a specified value in a dataset. If there is more than one entry of the same value in the dataset, the average rank of the entries will be returned.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__RANK_EQ__(value, data, is_ascending=None)</code> {: #rank_eq }
+#### <code>__RANK_EQ__(value, data, is_ascending=None)</code> {: #rank_eq data-toc-label="RANK_EQ" }
 </summary>
 Returns the rank of a specified value in a dataset. If there is more than one entry of the same value in the dataset, the top rank of the entries will be returned.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__RSQ__(data_y, data_x)</code> {: #rsq }
+#### <code>__RSQ__(data_y, data_x)</code> {: #rsq data-toc-label="RSQ" }
 </summary>
 Calculates the square of r, the Pearson product-moment correlation coefficient of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__SKEW__(value1, value2)</code> {: #skew }
+#### <code>__SKEW__(value1, value2)</code> {: #skew data-toc-label="SKEW" }
 </summary>
 Calculates the skewness of a dataset, which describes the symmetry of that dataset about the mean.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__SLOPE__(data_y, data_x)</code> {: #slope }
+#### <code>__SLOPE__(data_y, data_x)</code> {: #slope data-toc-label="SLOPE" }
 </summary>
 Calculates the slope of the line resulting from linear regression of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__SMALL__(data, n)</code> {: #small }
+#### <code>__SMALL__(data, n)</code> {: #small data-toc-label="SMALL" }
 </summary>
 Returns the nth smallest element from a data set, where n is user-defined.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__STANDARDIZE__(value, mean, standard_deviation)</code> {: #standardize }
+#### <code>__STANDARDIZE__(value, mean, standard_deviation)</code> {: #standardize data-toc-label="STANDARDIZE" }
 </summary>
 Calculates the normalized equivalent of a random variable given mean and standard deviation of the distribution.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details markdown><summary >
-#### <code>__STDEV__(value, *more_values)</code> {: #stdev }
+#### <code>__STDEV__(value, *more_values)</code> {: #stdev data-toc-label="STDEV" }
 </summary>
 Calculates the standard deviation based on a sample, ignoring non-numerical values.
 
@@ -4088,7 +4088,7 @@ ZeroDivisionError: float division by zero
 
 </details>
 <details markdown><summary >
-#### <code>__STDEVA__(value, *more_values)</code> {: #stdeva }
+#### <code>__STDEVA__(value, *more_values)</code> {: #stdeva data-toc-label="STDEVA" }
 </summary>
 Calculates the standard deviation based on a sample, setting text to the value `0`.
 
@@ -4122,7 +4122,7 @@ ZeroDivisionError: float division by zero
 
 </details>
 <details markdown><summary >
-#### <code>__STDEVP__(value, *more_values)</code> {: #stdevp }
+#### <code>__STDEVP__(value, *more_values)</code> {: #stdevp data-toc-label="STDEVP" }
 </summary>
 Calculates the standard deviation based on an entire population, ignoring non-numerical values.
 
@@ -4154,7 +4154,7 @@ Calculates the standard deviation based on an entire population, ignoring non-nu
 
 </details>
 <details markdown><summary >
-#### <code>__STDEVPA__(value, *more_values)</code> {: #stdevpa }
+#### <code>__STDEVPA__(value, *more_values)</code> {: #stdevpa data-toc-label="STDEVPA" }
 </summary>
 Calculates the standard deviation based on an entire population, setting text to the value `0`.
 
@@ -4186,84 +4186,84 @@ Calculates the standard deviation based on an entire population, setting text to
 
 </details>
 <details>
-#### <code>__STEYX__(data_y, data_x)</code> {: #steyx }
+#### <code>__STEYX__(data_y, data_x)</code> {: #steyx data-toc-label="STEYX" }
 </summary>
 Calculates the standard error of the predicted y-value for each x in the regression of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__TDIST__(x, degrees_freedom, tails)</code> {: #tdist }
+#### <code>__TDIST__(x, degrees_freedom, tails)</code> {: #tdist data-toc-label="TDIST" }
 </summary>
 Calculates the probability for Student's t-distribution with a given input (x).
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__TINV__(probability, degrees_freedom)</code> {: #tinv }
+#### <code>__TINV__(probability, degrees_freedom)</code> {: #tinv data-toc-label="TINV" }
 </summary>
 Calculates the inverse of the two-tailed TDIST function.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__TRIMMEAN__(data, exclude_proportion)</code> {: #trimmean }
+#### <code>__TRIMMEAN__(data, exclude_proportion)</code> {: #trimmean data-toc-label="TRIMMEAN" }
 </summary>
 Calculates the mean of a dataset excluding some proportion of data from the high and low ends of the dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__TTEST__(range1, range2, tails, type)</code> {: #ttest }
+#### <code>__TTEST__(range1, range2, tails, type)</code> {: #ttest data-toc-label="TTEST" }
 </summary>
 Returns the probability associated with t-test. Determines whether two samples are likely to have come from the same two underlying populations that have the same mean.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__T_INV__(probability, degrees_freedom)</code> {: #t_inv }
+#### <code>__T_INV__(probability, degrees_freedom)</code> {: #t_inv data-toc-label="T_INV" }
 </summary>
 Calculates the negative inverse of the one-tailed TDIST function.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__T_INV_2T__(probability, degrees_freedom)</code> {: #t_inv_2t }
+#### <code>__T_INV_2T__(probability, degrees_freedom)</code> {: #t_inv_2t data-toc-label="T_INV_2T" }
 </summary>
 Calculates the inverse of the two-tailed TDIST function.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__VAR__(value1, value2)</code> {: #var }
+#### <code>__VAR__(value1, value2)</code> {: #var data-toc-label="VAR" }
 </summary>
 Calculates the variance based on a sample.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__VARA__(value1, value2)</code> {: #vara }
+#### <code>__VARA__(value1, value2)</code> {: #vara data-toc-label="VARA" }
 </summary>
 Calculates an estimate of variance based on a sample, setting text to the value `0`.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__VARP__(value1, value2)</code> {: #varp }
+#### <code>__VARP__(value1, value2)</code> {: #varp data-toc-label="VARP" }
 </summary>
 Calculates the variance based on an entire population.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__VARPA__(value1, value2)</code> {: #varpa }
+#### <code>__VARPA__(value1, value2)</code> {: #varpa data-toc-label="VARPA" }
 </summary>
 Calculates the variance based on an entire population, setting text to the value `0`.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__WEIBULL__(x, shape, scale, cumulative)</code> {: #weibull }
+#### <code>__WEIBULL__(x, shape, scale, cumulative)</code> {: #weibull data-toc-label="WEIBULL" }
 </summary>
 Returns the value of the Weibull distribution function (or Weibull cumulative distribution
 function) for a specified shape and scale.
@@ -4271,7 +4271,7 @@ function) for a specified shape and scale.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details>
-#### <code>__ZTEST__(data, value, standard_deviation)</code> {: #ztest }
+#### <code>__ZTEST__(data, value, standard_deviation)</code> {: #ztest data-toc-label="ZTEST" }
 </summary>
 Returns the two-tailed P-value of a Z-test with standard distribution.
 
@@ -4279,7 +4279,7 @@ Returns the two-tailed P-value of a Z-test with standard distribution.
 </details>
 ### Text
 <details markdown><summary >
-#### <code>__CHAR__(table_number)</code> {: #char }
+#### <code>__CHAR__(table_number)</code> {: #char data-toc-label="CHAR" }
 </summary>
 Convert a number into a character according to the current Unicode table.
 Same as `unichr(number)`.
@@ -4297,7 +4297,7 @@ u'!'
 
 </details>
 <details markdown><summary >
-#### <code>__CLEAN__(text)</code> {: #clean }
+#### <code>__CLEAN__(text)</code> {: #clean data-toc-label="CLEAN" }
 </summary>
 Returns the text with the non-printable characters removed.
 
@@ -4312,7 +4312,7 @@ u'Monthly report'
 
 </details>
 <details markdown><summary >
-#### <code>__CODE__(string)</code> {: #code }
+#### <code>__CODE__(string)</code> {: #code data-toc-label="CODE" }
 </summary>
 Returns the numeric Unicode map value of the first character in the string provided.
 Same as `ord(string[0])`.
@@ -4335,7 +4335,7 @@ Same as `ord(string[0])`.
 
 </details>
 <details markdown><summary >
-#### <code>__CONCAT__(string, *more_strings)</code> {: #concat }
+#### <code>__CONCAT__(string, *more_strings)</code> {: #concat data-toc-label="CONCAT" }
 </summary>
 Joins together any number of text strings into one string. Also available under the name
 `CONCATENATE`. Similar to the Python expression `"".join(array_of_strings)`.
@@ -4368,7 +4368,7 @@ u'0abc'
 
 </details>
 <details markdown><summary >
-#### <code>__CONCATENATE__(string, *more_strings)</code> {: #concatenate }
+#### <code>__CONCATENATE__(string, *more_strings)</code> {: #concatenate data-toc-label="CONCATENATE" }
 </summary>
 Joins together any number of text strings into one string. Also available under the name
 `CONCAT`. Similar to the Python expression `"".join(array_of_strings)`.
@@ -4411,7 +4411,7 @@ u'0abc'
 
 </details>
 <details markdown><summary >
-#### <code>__DOLLAR__(number, decimals=2)</code> {: #dollar }
+#### <code>__DOLLAR__(number, decimals=2)</code> {: #dollar data-toc-label="DOLLAR" }
 </summary>
 Formats a number into a formatted dollar amount, with decimals rounded to the specified place (.
 If decimals value is omitted, it defaults to 2.
@@ -4454,7 +4454,7 @@ If decimals value is omitted, it defaults to 2.
 
 </details>
 <details markdown><summary >
-#### <code>__EXACT__(string1, string2)</code> {: #exact }
+#### <code>__EXACT__(string1, string2)</code> {: #exact data-toc-label="EXACT" }
 </summary>
 Tests whether two strings are identical. Same as `string2 == string2`.
 
@@ -4476,7 +4476,7 @@ False
 
 </details>
 <details markdown><summary >
-#### <code>__FIND__(find_text, within_text, start_num=1)</code> {: #find }
+#### <code>__FIND__(find_text, within_text, start_num=1)</code> {: #find data-toc-label="FIND" }
 </summary>
 Returns the position at which a string is first found within text.
 
@@ -4533,7 +4533,7 @@ ValueError: substring not found
 
 </details>
 <details markdown><summary >
-#### <code>__FIXED__(number, decimals=2, no_commas=False)</code> {: #fixed }
+#### <code>__FIXED__(number, decimals=2, no_commas=False)</code> {: #fixed data-toc-label="FIXED" }
 </summary>
 Formats a number with a fixed number of decimal places (2 by default), and commas.
 If no_commas is True, then omits the commas.
@@ -4581,7 +4581,7 @@ If no_commas is True, then omits the commas.
 
 </details>
 <details markdown><summary >
-#### <code>__LEFT__(string, num_chars=1)</code> {: #left }
+#### <code>__LEFT__(string, num_chars=1)</code> {: #left data-toc-label="LEFT" }
 </summary>
 Returns a substring of length num_chars from the beginning of the given string. If num_chars is
 omitted, it is assumed to be 1. Same as `string[:num_chars]`.
@@ -4606,7 +4606,7 @@ ValueError: num_chars invalid
 
 </details>
 <details markdown><summary >
-#### <code>__LEN__(text)</code> {: #len }
+#### <code>__LEN__(text)</code> {: #len data-toc-label="LEN" }
 </summary>
 Returns the number of characters in a text string, or the number of items in a list. Same as
 [`len`](https://docs.python.org/3/library/functions.html#len) in python.
@@ -4630,7 +4630,7 @@ See [Record Set](#recordset) for an example of using `len` on a list of records.
 
 </details>
 <details markdown><summary >
-#### <code>__LOWER__(text)</code> {: #lower }
+#### <code>__LOWER__(text)</code> {: #lower data-toc-label="LOWER" }
 </summary>
 Converts a specified string to lowercase. Same as `text.lower()`.
 
@@ -4647,7 +4647,7 @@ Converts a specified string to lowercase. Same as `text.lower()`.
 
 </details>
 <details markdown><summary >
-#### <code>__MID__(text, start_num, num_chars)</code> {: #mid }
+#### <code>__MID__(text, start_num, num_chars)</code> {: #mid data-toc-label="MID" }
 </summary>
 Returns a segment of a string, starting at start_num. The first character in text has
 start_num 1.
@@ -4677,7 +4677,7 @@ ValueError: start_num invalid
 
 </details>
 <details markdown><summary >
-#### <code>__PHONE_FORMAT__(value, country=None, format=None)</code> {: #phone_format }
+#### <code>__PHONE_FORMAT__(value, country=None, format=None)</code> {: #phone_format data-toc-label="PHONE_FORMAT" }
 </summary>
 Formats a phone number.
 
@@ -4781,7 +4781,7 @@ TypeError: Phone number must be a text value. If formatting a value from a Numer
 
 </details>
 <details markdown><summary >
-#### <code>__PROPER__(text)</code> {: #proper }
+#### <code>__PROPER__(text)</code> {: #proper data-toc-label="PROPER" }
 </summary>
 Capitalizes each word in a specified string. It converts the first letter of each word to
 uppercase, and all other letters to lowercase. Same as `text.title()`.
@@ -4804,7 +4804,7 @@ uppercase, and all other letters to lowercase. Same as `text.title()`.
 
 </details>
 <details markdown><summary >
-#### <code>__REGEXEXTRACT__(text, regular_expression)</code> {: #regexextract }
+#### <code>__REGEXEXTRACT__(text, regular_expression)</code> {: #regexextract data-toc-label="REGEXEXTRACT" }
 </summary>
 Extracts the first part of text that matches regular_expression.
 
@@ -4835,7 +4835,7 @@ ValueError: REGEXEXTRACT text does not match
 
 </details>
 <details markdown><summary >
-#### <code>__REGEXMATCH__(text, regular_expression)</code> {: #regexmatch }
+#### <code>__REGEXMATCH__(text, regular_expression)</code> {: #regexmatch data-toc-label="REGEXMATCH" }
 </summary>
 Returns whether a piece of text matches a regular expression.
 
@@ -4867,7 +4867,7 @@ False
 
 </details>
 <details markdown><summary >
-#### <code>__REGEXREPLACE__(text, regular_expression, replacement)</code> {: #regexreplace }
+#### <code>__REGEXREPLACE__(text, regular_expression, replacement)</code> {: #regexreplace data-toc-label="REGEXREPLACE" }
 </summary>
 Replaces all parts of text matching the given regular expression with replacement text.
 
@@ -4899,7 +4899,7 @@ Replaces all parts of text matching the given regular expression with replacemen
 
 </details>
 <details markdown><summary >
-#### <code>__REPLACE__(text, position, length, new_text)</code> {: #replace }
+#### <code>__REPLACE__(text, position, length, new_text)</code> {: #replace data-toc-label="REPLACE" }
 </summary>
 Replaces part of a text string with a different text string. Position is counted from 1.
 
@@ -4933,7 +4933,7 @@ ValueError: position invalid
 
 </details>
 <details markdown><summary >
-#### <code>__REPT__(text, number_times)</code> {: #rept }
+#### <code>__REPT__(text, number_times)</code> {: #rept data-toc-label="REPT" }
 </summary>
 Returns specified text repeated a number of times. Same as `text * number_times`.
 
@@ -4977,7 +4977,7 @@ ValueError: number_times invalid
 
 </details>
 <details markdown><summary >
-#### <code>__RIGHT__(string, num_chars=1)</code> {: #right }
+#### <code>__RIGHT__(string, num_chars=1)</code> {: #right data-toc-label="RIGHT" }
 </summary>
 Returns a substring of length num_chars from the end of a specified string. If num_chars is
 omitted, it is assumed to be 1. Same as `string[-num_chars:]`.
@@ -5007,7 +5007,7 @@ ValueError: num_chars invalid
 
 </details>
 <details markdown><summary >
-#### <code>__SEARCH__(find_text, within_text, start_num=1)</code> {: #search }
+#### <code>__SEARCH__(find_text, within_text, start_num=1)</code> {: #search data-toc-label="SEARCH" }
 </summary>
 Returns the position at which a string is first found within text, ignoring case.
 
@@ -5049,7 +5049,7 @@ If find_text is not found, or start_num is invalid, raises ValueError.
 
 </details>
 <details markdown><summary >
-#### <code>__SUBSTITUTE__(text, old_text, new_text, instance_num=None)</code> {: #substitute }
+#### <code>__SUBSTITUTE__(text, old_text, new_text, instance_num=None)</code> {: #substitute data-toc-label="SUBSTITUTE" }
 </summary>
 Replaces existing text with new text in a string. It is useful when you know the substring of
 text to replace. Use REPLACE when you know the position of text to replace.
@@ -5076,7 +5076,7 @@ u'Quarter 1, 2012'
 ```
 </details>
 <details markdown><summary >
-#### <code>__T__(value)</code> {: #t }
+#### <code>__T__(value)</code> {: #t data-toc-label="T" }
 </summary>
 Returns value if value is text, or the empty string when value is not text.
 
@@ -5118,7 +5118,7 @@ u''
 
 </details>
 <details markdown><summary >
-#### <code>__TASTEME__(food)</code> {: #tasteme }
+#### <code>__TASTEME__(food)</code> {: #tasteme data-toc-label="TASTEME" }
 </summary>
 For any given piece of text, decides if it is tasty or not.
 
@@ -5139,7 +5139,7 @@ False
 
 </details>
 <details>
-#### <code>__TEXT__(number, format_type)</code> {: #text }
+#### <code>__TEXT__(number, format_type)</code> {: #text data-toc-label="TEXT" }
 </summary>
 Converts a number into text according to a specified format. It is not yet implemented in
 Grist. You can use the similar Python functions str() to convert numbers into strings, and
@@ -5148,7 +5148,7 @@ optionally format() to specify the number format.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details markdown><summary >
-#### <code>__TRIM__(text)</code> {: #trim }
+#### <code>__TRIM__(text)</code> {: #trim data-toc-label="TRIM" }
 </summary>
 Removes all spaces from text except for single spaces between words. Note that TRIM does not
 remove other whitespace such as tab or newline characters.
@@ -5166,7 +5166,7 @@ remove other whitespace such as tab or newline characters.
 
 </details>
 <details markdown><summary >
-#### <code>__UPPER__(text)</code> {: #upper }
+#### <code>__UPPER__(text)</code> {: #upper data-toc-label="UPPER" }
 </summary>
 Converts a specified string to uppercase. Same as `text.upper()`.
 
@@ -5183,7 +5183,7 @@ Converts a specified string to uppercase. Same as `text.upper()`.
 
 </details>
 <details markdown><summary >
-#### <code>__VALUE__(text)</code> {: #value }
+#### <code>__VALUE__(text)</code> {: #value data-toc-label="VALUE" }
 </summary>
 Converts a string in accepted date, time or number formats into a number or date.
 

--- a/help/en/docs/functions.md
+++ b/help/en/docs/functions.md
@@ -43,7 +43,7 @@ Python (see [Python documentation](https://docs.python.org/3.11/)). Here are som
 
 <!-- BEGIN mkpydocs docs -->
 ### Grist
-<details id="record" markdown><summary >
+<details markdown><summary >
 #### <code>class __Record__</code> {: #record }
 </summary>
 A Record represents a record of data. It is the primary means of accessing values in formulas. A
@@ -61,12 +61,12 @@ def Name_Length(rec, table):
   return len(rec.Full_Name)
 ```
 </details>
-<details id="_field" markdown><summary >
+<details markdown><summary >
 #### <code>__$__*Field* or __rec__*.Field*</code> {: #_field }
 </summary>
 Access the field named "Field" of the current record. E.g. `$First_Name` or `rec.First_Name`.
 </details>
-<details id="_group" markdown><summary >
+<details markdown><summary >
 #### <code>__$group__</code> {: #_group }
 </summary>
 In a [summary table](summary-tables.md), `$group` is a special field
@@ -83,7 +83,7 @@ sum(r.Amount for r in $group if r > 0)    # Sum of only the positive amounts
 sum(r.Shares * r.Price for r in $group)   # Sum of shares * price products
 ```
 </details>
-<details id="recordset" markdown><summary >
+<details markdown><summary >
 #### <code>class __RecordSet__</code> {: #recordset }
 </summary>
 A RecordSet represents a collection of records, as returned by `Table.lookupRecords()` or
@@ -104,7 +104,7 @@ min(Tasks.lookupRecords(Owner="Bob").DueDate)
 
 You can get the number of records in a RecordSet using `len`, e.g. `len($group)`.
 </details>
-<details id="find_" markdown><summary >
+<details markdown><summary >
 #### <code>RecordSet.**find.\***(value)</code> {: #find_ }
 </summary>
 A set of methods for finding values in sorted sets of records, as returned by
@@ -150,7 +150,7 @@ return rate.Hourly_Rate
 
 Note that this is also much faster when there are many rates for the same Person and Role.
 </details>
-<details id="usertable" markdown><summary >
+<details markdown><summary >
 #### <code>class __UserTable__</code> {: #usertable }
 </summary>
 Each data table in the document is represented in the code by an instance of `UserTable` class.
@@ -159,7 +159,7 @@ as well as methods to look up particular records.
 
 Every table in the document is available to all formulas.
 </details>
-<details id="all" markdown><summary >
+<details markdown><summary >
 #### <code>UserTable.__all__</code> {: #all }
 </summary>
 The list of all the records in this table.
@@ -174,7 +174,7 @@ This evaluates to the sum of the `Population` field for every record in the tabl
 sum(r.Population for r in Countries.all)
 ```
 </details>
-<details id="lookupone" markdown><summary >
+<details markdown><summary >
 #### <code>UserTable.__lookupOne__(Field_In_Lookup_Table=value, ...)</code> {: #lookupone }
 </summary>
 Returns a [Record](#record) matching the given field=value arguments. The value may be any
@@ -203,7 +203,7 @@ Tasks.lookupOne(Project=$id, order_by="Priority")  # Task with the smallest Prio
 Rates.lookupOne(Person=$id, order_by="-Date")      # Rate with the latest Date.
 ```
 </details>
-<details id="lookuprecords" markdown><summary >
+<details markdown><summary >
 #### <code>UserTable.__lookupRecords__(Field_In_Lookup_Table=value, ...)</code> {: #lookuprecords }
 </summary>
 Returns a [RecordSet](#recordset) matching the given field=value arguments. The value may be
@@ -247,13 +247,13 @@ value.
 Learn more about [lookupRecords](references-lookups.md#lookuprecords).
 </details>
 ### Cumulative
-<details id="next" markdown><summary >
+<details markdown><summary >
 #### <code>__NEXT__(rec, *, group_by=(), order_by)</code> {: #next }
 </summary>
 Finds the next record in the table according to the order specified by `order_by`, and
 grouping specified by `group_by`. See [`PREVIOUS`](#previous) for details.
 </details>
-<details id="previous" markdown><summary >
+<details markdown><summary >
 #### <code>__PREVIOUS__(rec, *, group_by=(), order_by)</code> {: #previous }
 </summary>
 Finds the previous record in the table according to the order specified by `order_by`, and
@@ -289,7 +289,7 @@ used to match views sorted by multiple columns. For example:
 PREVIOUS(rec, group_by=("Account", "Year"), order_by=("Date", "-Amount"))
 ```
 </details>
-<details id="rank" markdown><summary >
+<details markdown><summary >
 #### <code>__RANK__(rec, *, group_by=(), order_by, order='asc')</code> {: #rank }
 </summary>
 Returns the rank (or position) of this record in the table according to the order specified by
@@ -310,7 +310,7 @@ the current record (`rec`) among all the records in its table for the same year,
 decreasing score.
 </details>
 ### Date
-<details id="date" markdown><summary >
+<details markdown><summary >
 #### <code>__DATE__(year, month, day)</code> {: #date }
 </summary>
 Returns the `datetime.datetime` object that represents a particular date.
@@ -357,7 +357,7 @@ If day is less than 1, subtracts that many days plus 1, from the first day of th
 datetime.date(2007, 12, 16)
 ```
 </details>
-<details id="dateadd" markdown><summary >
+<details markdown><summary >
 #### <code>__DATEADD__(start_date, days=0, months=0, years=0, weeks=0)</code> {: #dateadd }
 </summary>
 Returns the date a given number of days, months, years, or weeks away from `start_date`. You may
@@ -388,7 +388,7 @@ datetime.date(2025, 3, 26)
 ```
 
 </details>
-<details id="datedif" markdown><summary >
+<details markdown><summary >
 #### <code>__DATEDIF__(start_date, end_date, unit)</code> {: #datedif }
 </summary>
 Calculates the number of days, months, or years between two dates.
@@ -432,7 +432,7 @@ The difference between 1 and 15, ignoring the months and the years of the dates 
 14
 ```
 </details>
-<details id="datevalue" markdown><summary >
+<details markdown><summary >
 #### <code>__DATEVALUE__(date_string, tz=None)</code> {: #datevalue }
 </summary>
 Converts a date that is stored as text to a `datetime` object.
@@ -465,7 +465,7 @@ In case of ambiguity, prefer M/D/Y format.
 datetime.datetime(2003, 1, 2, 0, 0, tzinfo=moment.tzinfo('America/New_York'))
 ```
 </details>
-<details id="date_to_xl" markdown><summary >
+<details markdown><summary >
 #### <code>__DATE_TO_XL__(date_value)</code> {: #date_to_xl }
 </summary>
 Converts a Python `date` or `datetime` object to the serial number as used by
@@ -489,7 +489,7 @@ See XL_TO_DATE for more explanation.
 40982.0625
 ```
 </details>
-<details id="day" markdown><summary >
+<details markdown><summary >
 #### <code>__DAY__(date)</code> {: #day }
 </summary>
 Returns the day of a date, as an integer ranging from 1 to 31. Same as `date.day`.
@@ -511,7 +511,7 @@ Returns the day of a date, as an integer ranging from 1 to 31. Same as `date.day
 ```
 
 </details>
-<details id="days" markdown><summary >
+<details markdown><summary >
 #### <code>__DAYS__(end_date, start_date)</code> {: #days }
 </summary>
 Returns the number of days between two dates. Same as `(end_date - start_date).days`.
@@ -533,7 +533,7 @@ Returns the number of days between two dates. Same as `(end_date - start_date).d
 ```
 
 </details>
-<details id="dtime" markdown><summary >
+<details markdown><summary >
 #### <code>__DTIME__(value, tz=None)</code> {: #dtime }
 </summary>
 Returns the value converted to a python `datetime` object. The value may be a
@@ -576,7 +576,7 @@ datetime.datetime(2008, 1, 1, 0, 0, tzinfo=moment.tzinfo('America/New_York'))
 ```
 
 </details>
-<details id="edate" markdown><summary >
+<details markdown><summary >
 #### <code>__EDATE__(start_date, months)</code> {: #edate }
 </summary>
 Returns the date that is the given number of months before or after `start_date`. Use
@@ -610,7 +610,7 @@ datetime.date(2012, 3, 1)
 ```
 
 </details>
-<details id="eomonth" markdown><summary >
+<details markdown><summary >
 #### <code>__EOMONTH__(start_date, months)</code> {: #eomonth }
 </summary>
 Returns the date for the last day of the month that is the indicated number of months before or
@@ -639,7 +639,7 @@ datetime.date(2012, 3, 31)
 ```
 
 </details>
-<details id="hour" markdown><summary >
+<details markdown><summary >
 #### <code>__HOUR__(time)</code> {: #hour }
 </summary>
 Same as `time.hour`.
@@ -661,7 +661,7 @@ Same as `time.hour`.
 ```
 
 </details>
-<details id="isoweeknum" markdown><summary >
+<details markdown><summary >
 #### <code>__ISOWEEKNUM__(date)</code> {: #isoweeknum }
 </summary>
 Returns the ISO week number of the year for a given date.
@@ -678,7 +678,7 @@ Returns the ISO week number of the year for a given date.
 ```
 
 </details>
-<details id="minute" markdown><summary >
+<details markdown><summary >
 #### <code>__MINUTE__(time)</code> {: #minute }
 </summary>
 Returns the minutes of `datetime`, as an integer from 0 to 59.
@@ -706,7 +706,7 @@ Same as `time.minute`.
 ```
 
 </details>
-<details id="month" markdown><summary >
+<details markdown><summary >
 #### <code>__MONTH__(date)</code> {: #month }
 </summary>
 Returns the month of a date represented, as an integer from from 1 (January) to 12 (December).
@@ -729,7 +729,7 @@ Same as `date.month`.
 ```
 
 </details>
-<details id="moonphase" markdown><summary >
+<details markdown><summary >
 #### <code>__MOONPHASE__(date, output='emoji')</code> {: #moonphase }
 </summary>
 Returns the phase of the moon on the given date. The output defaults to a moon-phase emoji.
@@ -778,12 +778,12 @@ True
 ```
 
 </details>
-<details id="now" markdown><summary >
+<details markdown><summary >
 #### <code>__NOW__(tz=None)</code> {: #now }
 </summary>
 Returns the `datetime` object for the current time.
 </details>
-<details id="second" markdown><summary >
+<details markdown><summary >
 #### <code>__SECOND__(time)</code> {: #second }
 </summary>
 Returns the seconds of `datetime`, as an integer from 0 to 59.
@@ -806,12 +806,12 @@ Same as `time.second`.
 ```
 
 </details>
-<details id="today" markdown><summary >
+<details markdown><summary >
 #### <code>__TODAY__(tz=None)</code> {: #today }
 </summary>
 Returns the `date` object for the current date.
 </details>
-<details id="weekday" markdown><summary >
+<details markdown><summary >
 #### <code>__WEEKDAY__(date, return_type=1)</code> {: #weekday }
 </summary>
 Returns the day of the week corresponding to a date. The day is given as an integer, ranging
@@ -856,7 +856,7 @@ Return_type determines the type of the returned value.
 3
 ```
 </details>
-<details id="weeknum" markdown><summary >
+<details markdown><summary >
 #### <code>__WEEKNUM__(date, return_type=1)</code> {: #weeknum }
 </summary>
 Returns the week number of a specific date. For example, the week containing January 1 is the
@@ -897,7 +897,7 @@ Return_type determines which week is considered the first week of the year.
 5
 ```
 </details>
-<details id="xl_to_date" markdown><summary >
+<details markdown><summary >
 #### <code>__XL_TO_DATE__(value, tz=None)</code> {: #xl_to_date }
 </summary>
 Converts a provided Excel serial number representing a date into a `datetime` object.
@@ -926,7 +926,7 @@ datetime.datetime(2008, 1, 1, 0, 0, tzinfo=moment.tzinfo('America/New_York'))
 datetime.datetime(2012, 3, 14, 1, 30, tzinfo=moment.tzinfo('America/New_York'))
 ```
 </details>
-<details id="year" markdown><summary >
+<details markdown><summary >
 #### <code>__YEAR__(date)</code> {: #year }
 </summary>
 Returns the year corresponding to a date as an integer.
@@ -949,7 +949,7 @@ Same as `date.year`.
 ```
 
 </details>
-<details id="yearfrac" markdown><summary >
+<details markdown><summary >
 #### <code>__YEARFRAC__(start_date, end_date, basis=0)</code> {: #yearfrac }
 </summary>
 Calculates the fraction of the year represented by the number of whole days between two dates.
@@ -998,14 +998,14 @@ Fraction between same dates, using the Actual/365 basis argument. Uses a 365 day
 ```
 </details>
 ### Info
-<details id="cell" markdown><summary class="unimplemented">
+<details>
 #### <code>__CELL__(info_type, reference)</code> {: #cell }
 </summary>
 Returns the requested information about the specified cell. This is not implemented in Grist
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="isblank" markdown><summary class="unimplemented">
+<details>
 #### <code>__ISBLANK__(value)</code> {: #isblank }
 </summary>
 Returns whether a value refers to an empty cell. It isn't implemented in Grist. To check for an
@@ -1013,7 +1013,7 @@ empty string, use `value == ""`.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="isemail" markdown><summary >
+<details markdown><summary >
 #### <code>__ISEMAIL__(value)</code> {: #isemail }
 </summary>
 Returns whether a value is a valid email address.
@@ -1043,7 +1043,7 @@ False
 False
 ```
 </details>
-<details id="iserr" markdown><summary >
+<details markdown><summary >
 #### <code>__ISERR__(value)</code> {: #iserr }
 </summary>
 Checks whether a value is an error. In other words, it returns true
@@ -1067,7 +1067,7 @@ For example:
 False
 ```
 </details>
-<details id="iserror" markdown><summary >
+<details markdown><summary >
 #### <code>__ISERROR__(value)</code> {: #iserror }
 </summary>
 Checks whether a value is an error or an invalid value. It is similar to `ISERR`, but also
@@ -1091,7 +1091,7 @@ True
 True
 ```
 </details>
-<details id="islogical" markdown><summary >
+<details markdown><summary >
 #### <code>__ISLOGICAL__(value)</code> {: #islogical }
 </summary>
 Checks whether a value is `True` or `False`.
@@ -1123,7 +1123,7 @@ False
 ```
 
 </details>
-<details id="isna" markdown><summary >
+<details markdown><summary >
 #### <code>__ISNA__(value)</code> {: #isna }
 </summary>
 Checks whether a value is the error `#N/A`.
@@ -1150,7 +1150,7 @@ False
 ```
 
 </details>
-<details id="isnontext" markdown><summary >
+<details markdown><summary >
 #### <code>__ISNONTEXT__(value)</code> {: #isnontext }
 </summary>
 Checks whether a value is non-textual.
@@ -1187,7 +1187,7 @@ True
 ```
 
 </details>
-<details id="isnumber" markdown><summary >
+<details markdown><summary >
 #### <code>__ISNUMBER__(value)</code> {: #isnumber }
 </summary>
 Checks whether a value is a number.
@@ -1233,7 +1233,7 @@ False
 False
 ```
 </details>
-<details id="isref" markdown><summary >
+<details markdown><summary >
 #### <code>__ISREF__(value)</code> {: #isref }
 </summary>
 Checks whether a value is a table record.
@@ -1255,7 +1255,7 @@ False
 ```
 
 </details>
-<details id="isreflist" markdown><summary >
+<details markdown><summary >
 #### <code>__ISREFLIST__(value)</code> {: #isreflist }
 </summary>
 Checks whether a value is a [`RecordSet`](#recordset),
@@ -1278,7 +1278,7 @@ False
 ```
 
 </details>
-<details id="istext" markdown><summary >
+<details markdown><summary >
 #### <code>__ISTEXT__(value)</code> {: #istext }
 </summary>
 Checks whether a value is text.
@@ -1315,7 +1315,7 @@ False
 ```
 
 </details>
-<details id="isurl" markdown><summary >
+<details markdown><summary >
 #### <code>__ISURL__(value)</code> {: #isurl }
 </summary>
 Checks whether a value is a valid URL. It does not need to be fully qualified, or to include
@@ -1345,7 +1345,7 @@ True
 False
 ```
 </details>
-<details id="n" markdown><summary >
+<details markdown><summary >
 #### <code>__N__(value)</code> {: #n }
 </summary>
 Returns the value converted to a number. True/False are converted to 1/0. A date is converted to
@@ -1383,7 +1383,7 @@ Excel-style serial number of the date. Anything else is converted to 0.
 ```
 
 </details>
-<details id="na" markdown><summary >
+<details markdown><summary >
 #### <code>__NA__()</code> {: #na }
 </summary>
 Returns the "value not available" error, `#N/A`.
@@ -1395,7 +1395,7 @@ True
 ```
 
 </details>
-<details id="peek" markdown><summary >
+<details markdown><summary >
 #### <code>__PEEK__(func)</code> {: #peek }
 </summary>
 Evaluates the given expression without creating dependencies
@@ -1408,7 +1408,7 @@ calculated before the other. But if `A` uses `PEEK($B)` then it will simply get 
 already stored in `$B` without requiring that `$B` is first calculated to the latest value.
 Therefore `A` will be calculated first, and `B` can use `$A` without problems.
 </details>
-<details id="record_2" markdown><summary >
+<details markdown><summary >
 #### <code>__RECORD__(record_or_list, dates_as_iso=False, expand_refs=0)</code> {: #record }
 </summary>
 Returns a Python dictionary with all fields in the given record. If a list of records is given,
@@ -1435,13 +1435,13 @@ RECORD(People.lookupOne(First_Name="Alice"))
 RECORD(People.lookupRecords(Department="HR"))
 ```
 </details>
-<details id="request" markdown><summary class="unimplemented">
+<details>
 #### <code>__REQUEST__(url, params=None, headers=None, method='GET', data=None, json=None)</code> {: #request }
 </summary>
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="type" markdown><summary class="unimplemented">
+<details>
 #### <code>__TYPE__(value)</code> {: #type }
 </summary>
 Returns a number associated with the type of data passed into the function. This is not
@@ -1450,7 +1450,7 @@ implemented in Grist. Use `isinstance(value, type)` or `type(value)`.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 ### Logical
-<details id="and" markdown><summary >
+<details markdown><summary >
 #### <code>__AND__(logical_expression, *logical_expressions)</code> {: #and }
 </summary>
 Returns True if all of the arguments are logically true, and False if any are false.
@@ -1483,7 +1483,7 @@ False
 ```
 
 </details>
-<details id="false" markdown><summary >
+<details markdown><summary >
 #### <code>__FALSE__()</code> {: #false }
 </summary>
 Returns the logical value `False`. You may also use the value `False` directly. This
@@ -1496,7 +1496,7 @@ False
 ```
 
 </details>
-<details id="if" markdown><summary >
+<details markdown><summary >
 #### <code>__IF__(logical_expression, value_if_true, value_if_false)</code> {: #if }
 </summary>
 Returns one value if a logical expression is `True` and another if it is `False`.
@@ -1539,7 +1539,7 @@ to evaluate to `1` rather than raise an exception.
 0.0
 ```
 </details>
-<details id="iferror" markdown><summary >
+<details markdown><summary >
 #### <code>__IFERROR__(value, value_if_error='')</code> {: #iferror }
 </summary>
 Returns the first argument if it is not an error value, otherwise returns the second argument if
@@ -1568,7 +1568,7 @@ NOTE: Grist handles values that raise an exception by wrapping them to use lazy 
 ''
 ```
 </details>
-<details id="not" markdown><summary >
+<details markdown><summary >
 #### <code>__NOT__(logical_expression)</code> {: #not }
 </summary>
 `True`. Same as `not logical_expression`.
@@ -1585,7 +1585,7 @@ True
 ```
 
 </details>
-<details id="or" markdown><summary >
+<details markdown><summary >
 #### <code>__OR__(logical_expression, *logical_expressions)</code> {: #or }
 </summary>
 Returns True if any of the arguments is logically true, and false if all of the
@@ -1629,7 +1629,7 @@ True
 ```
 
 </details>
-<details id="true" markdown><summary >
+<details markdown><summary >
 #### <code>__TRUE__()</code> {: #true }
 </summary>
 Returns the logical value `True`. You may also use the value `True` directly. This
@@ -1643,7 +1643,7 @@ True
 
 </details>
 ### Lookup
-<details id="lookupone_2" markdown><summary >
+<details markdown><summary >
 #### <code>UserTable.__lookupOne__(Field_In_Lookup_Table=value, ...)</code> {: #lookupone }
 </summary>
 Returns a [Record](#record) matching the given field=value arguments. The value may be any
@@ -1672,7 +1672,7 @@ Tasks.lookupOne(Project=$id, order_by="Priority")  # Task with the smallest Prio
 Rates.lookupOne(Person=$id, order_by="-Date")      # Rate with the latest Date.
 ```
 </details>
-<details id="lookuprecords_2" markdown><summary >
+<details markdown><summary >
 #### <code>UserTable.__lookupRecords__(Field_In_Lookup_Table=value, ...)</code> {: #lookuprecords }
 </summary>
 Returns a [RecordSet](#recordset) matching the given field=value arguments. The value may be
@@ -1715,35 +1715,35 @@ value.
 
 Learn more about [lookupRecords](references-lookups.md#lookuprecords).
 </details>
-<details id="address" markdown><summary class="unimplemented">
+<details>
 #### <code>__ADDRESS__(row, column, absolute_relative_mode, use_a1_notation, sheet)</code> {: #address }
 </summary>
 Returns a cell reference as a string.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="choose" markdown><summary class="unimplemented">
+<details>
 #### <code>__CHOOSE__(index, choice1, choice2)</code> {: #choose }
 </summary>
 Returns an element from a list of choices based on index.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="column" markdown><summary class="unimplemented">
+<details>
 #### <code>__COLUMN__(cell_reference=None)</code> {: #column }
 </summary>
 Returns the column number of a specified cell, with `A=1`.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="columns" markdown><summary class="unimplemented">
+<details>
 #### <code>__COLUMNS__(range)</code> {: #columns }
 </summary>
 Returns the number of columns in a specified array or range.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="contains" markdown><summary >
+<details markdown><summary >
 #### <code>__CONTAINS__(value, match_empty=no_match_empty)</code> {: #contains }
 </summary>
 Use this marker with [UserTable.lookupRecords](#lookuprecords) to find records
@@ -1773,77 +1773,77 @@ For example, given this formula:
 If `g` is `''` (i.e. equal to `match_empty`) then the column `genre` in the returned records
 will either be an empty list (or other container) or a list containing `g` as usual.
 </details>
-<details id="getpivotdata" markdown><summary class="unimplemented">
+<details>
 #### <code>__GETPIVOTDATA__(value_name, any_pivot_table_cell, original_column_1, pivot_item_1=None, *args)</code> {: #getpivotdata }
 </summary>
 Extracts an aggregated value from a pivot table that corresponds to the specified row and column headings.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="hlookup" markdown><summary class="unimplemented">
+<details>
 #### <code>__HLOOKUP__(search_key, range, index, is_sorted)</code> {: #hlookup }
 </summary>
 Horizontal lookup. Searches across the first row of a range for a key and returns the value of a specified cell in the column found.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="hyperlink" markdown><summary class="unimplemented">
+<details>
 #### <code>__HYPERLINK__(url, link_label)</code> {: #hyperlink }
 </summary>
 Creates a hyperlink inside a cell.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="index" markdown><summary class="unimplemented">
+<details>
 #### <code>__INDEX__(reference, row, column)</code> {: #index }
 </summary>
 Returns the content of a cell, specified by row and column offset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="indirect" markdown><summary class="unimplemented">
+<details>
 #### <code>__INDIRECT__(cell_reference_as_string)</code> {: #indirect }
 </summary>
 Returns a cell reference specified by a string.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="lookup" markdown><summary class="unimplemented">
+<details>
 #### <code>__LOOKUP__(search_key, search_range_or_search_result_array, result_range=None)</code> {: #lookup }
 </summary>
 Looks through a row or column for a key and returns the value of the cell in a result range located in the same position as the search row or column.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="match" markdown><summary class="unimplemented">
+<details>
 #### <code>__MATCH__(search_key, range, search_type)</code> {: #match }
 </summary>
 Returns the relative position of an item in a range that matches a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="offset" markdown><summary class="unimplemented">
+<details>
 #### <code>__OFFSET__(cell_reference, offset_rows, offset_columns, height, width)</code> {: #offset }
 </summary>
 Returns a range reference shifted a specified number of rows and columns from a starting cell reference.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="row" markdown><summary class="unimplemented">
+<details>
 #### <code>__ROW__(cell_reference)</code> {: #row }
 </summary>
 Returns the row number of a specified cell.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="rows" markdown><summary class="unimplemented">
+<details>
 #### <code>__ROWS__(range)</code> {: #rows }
 </summary>
 Returns the number of rows in a specified array or range.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="self_hyperlink" markdown><summary >
+<details markdown><summary >
 #### <code>__SELF_HYPERLINK__(label=None, page=None, **kwargs)</code> {: #self_hyperlink }
 </summary>
 Creates a link to the current document.  All parameters are optional.
@@ -1894,7 +1894,7 @@ TypeError: unexpected keyword argument 'Linky_Link' (not of form LinkKey_NAME)
 ```
 
 </details>
-<details id="vlookup" markdown><summary >
+<details markdown><summary >
 #### <code>__VLOOKUP__(table, **field_value_pairs)</code> {: #vlookup }
 </summary>
 Vertical lookup. Searches the given table for a record matching the given `field=value`
@@ -1917,7 +1917,7 @@ VLOOKUP(People, First_Name="Lewis", Last_Name="Carroll").Age
 ```
 </details>
 ### Math
-<details id="abs" markdown><summary >
+<details markdown><summary >
 #### <code>__ABS__(value)</code> {: #abs }
 </summary>
 Returns the absolute value of a number.
@@ -1939,7 +1939,7 @@ Returns the absolute value of a number.
 ```
 
 </details>
-<details id="acos" markdown><summary >
+<details markdown><summary >
 #### <code>__ACOS__(value)</code> {: #acos }
 </summary>
 Returns the inverse cosine of a value, in radians.
@@ -1956,7 +1956,7 @@ Returns the inverse cosine of a value, in radians.
 ```
 
 </details>
-<details id="acosh" markdown><summary >
+<details markdown><summary >
 #### <code>__ACOSH__(value)</code> {: #acosh }
 </summary>
 Returns the inverse hyperbolic cosine of a number.
@@ -1973,7 +1973,7 @@ Returns the inverse hyperbolic cosine of a number.
 ```
 
 </details>
-<details id="arabic" markdown><summary >
+<details markdown><summary >
 #### <code>__ARABIC__(roman_numeral)</code> {: #arabic }
 </summary>
 Computes the value of a Roman numeral.
@@ -1990,7 +1990,7 @@ Computes the value of a Roman numeral.
 ```
 
 </details>
-<details id="asin" markdown><summary >
+<details markdown><summary >
 #### <code>__ASIN__(value)</code> {: #asin }
 </summary>
 Returns the inverse sine of a value, in radians.
@@ -2012,7 +2012,7 @@ Returns the inverse sine of a value, in radians.
 ```
 
 </details>
-<details id="asinh" markdown><summary >
+<details markdown><summary >
 #### <code>__ASINH__(value)</code> {: #asinh }
 </summary>
 Returns the inverse hyperbolic sine of a number.
@@ -2029,7 +2029,7 @@ Returns the inverse hyperbolic sine of a number.
 ```
 
 </details>
-<details id="atan" markdown><summary >
+<details markdown><summary >
 #### <code>__ATAN__(value)</code> {: #atan }
 </summary>
 Returns the inverse tangent of a value, in radians.
@@ -2051,7 +2051,7 @@ Returns the inverse tangent of a value, in radians.
 ```
 
 </details>
-<details id="atan2" markdown><summary >
+<details markdown><summary >
 #### <code>__ATAN2__(x, y)</code> {: #atan2 }
 </summary>
 Returns the angle between the x-axis and a line segment from the origin (0,0) to specified
@@ -2084,7 +2084,7 @@ coordinate pair (`x`,`y`), in radians.
 ```
 
 </details>
-<details id="atanh" markdown><summary >
+<details markdown><summary >
 #### <code>__ATANH__(value)</code> {: #atanh }
 </summary>
 Returns the inverse hyperbolic tangent of a number.
@@ -2101,7 +2101,7 @@ Returns the inverse hyperbolic tangent of a number.
 ```
 
 </details>
-<details id="ceiling" markdown><summary >
+<details markdown><summary >
 #### <code>__CEILING__(value, factor=1)</code> {: #ceiling }
 </summary>
 Rounds a number up to the nearest multiple of factor, or the nearest integer if the factor is
@@ -2134,7 +2134,7 @@ omitted or 1.
 ```
 
 </details>
-<details id="combin" markdown><summary >
+<details markdown><summary >
 #### <code>__COMBIN__(n, k)</code> {: #combin }
 </summary>
 Returns the number of ways to choose some number of objects from a pool of a given size of
@@ -2157,7 +2157,7 @@ objects.
 ```
 
 </details>
-<details id="cos" markdown><summary >
+<details markdown><summary >
 #### <code>__COS__(angle)</code> {: #cos }
 </summary>
 Returns the cosine of an angle provided in radians.
@@ -2179,7 +2179,7 @@ Returns the cosine of an angle provided in radians.
 ```
 
 </details>
-<details id="cosh" markdown><summary >
+<details markdown><summary >
 #### <code>__COSH__(value)</code> {: #cosh }
 </summary>
 Returns the hyperbolic cosine of any real number.
@@ -2196,7 +2196,7 @@ Returns the hyperbolic cosine of any real number.
 ```
 
 </details>
-<details id="degrees" markdown><summary >
+<details markdown><summary >
 #### <code>__DEGREES__(angle)</code> {: #degrees }
 </summary>
 Converts an angle value in radians to degrees.
@@ -2213,7 +2213,7 @@ Converts an angle value in radians to degrees.
 ```
 
 </details>
-<details id="even" markdown><summary >
+<details markdown><summary >
 #### <code>__EVEN__(value)</code> {: #even }
 </summary>
 Rounds a number up to the nearest even integer, rounding away from zero.
@@ -2240,7 +2240,7 @@ Rounds a number up to the nearest even integer, rounding away from zero.
 ```
 
 </details>
-<details id="exp" markdown><summary >
+<details markdown><summary >
 #### <code>__EXP__(exponent)</code> {: #exp }
 </summary>
 Returns Euler's number, e (~2.718) raised to a power.
@@ -2257,7 +2257,7 @@ Returns Euler's number, e (~2.718) raised to a power.
 ```
 
 </details>
-<details id="fact" markdown><summary >
+<details markdown><summary >
 #### <code>__FACT__(value)</code> {: #fact }
 </summary>
 Returns the factorial of a number.
@@ -2291,7 +2291,7 @@ ValueError: factorial() not defined for negative values
 ```
 
 </details>
-<details id="factdouble" markdown><summary >
+<details markdown><summary >
 #### <code>__FACTDOUBLE__(value)</code> {: #factdouble }
 </summary>
 Returns the "double factorial" of a number.
@@ -2318,7 +2318,7 @@ Returns the "double factorial" of a number.
 ```
 
 </details>
-<details id="floor" markdown><summary >
+<details markdown><summary >
 #### <code>__FLOOR__(value, factor=1)</code> {: #floor }
 </summary>
 Rounds a number down to the nearest integer multiple of specified significance.
@@ -2352,7 +2352,7 @@ ValueError: factor argument invalid
 ```
 
 </details>
-<details id="gcd" markdown><summary >
+<details markdown><summary >
 #### <code>__GCD__(value1, *more_values)</code> {: #gcd }
 </summary>
 Returns the greatest common divisor of one or more integers.
@@ -2394,7 +2394,7 @@ Returns the greatest common divisor of one or more integers.
 ```
 
 </details>
-<details id="int" markdown><summary >
+<details markdown><summary >
 #### <code>__INT__(value)</code> {: #int }
 </summary>
 Rounds a number down to the nearest integer that is less than or equal to it.
@@ -2416,7 +2416,7 @@ Rounds a number down to the nearest integer that is less than or equal to it.
 ```
 
 </details>
-<details id="lcm" markdown><summary >
+<details markdown><summary >
 #### <code>__LCM__(value1, *more_values)</code> {: #lcm }
 </summary>
 Returns the least common multiple of one or more integers.
@@ -2458,7 +2458,7 @@ Returns the least common multiple of one or more integers.
 ```
 
 </details>
-<details id="ln" markdown><summary >
+<details markdown><summary >
 #### <code>__LN__(value)</code> {: #ln }
 </summary>
 Returns the the logarithm of a number, base e (Euler's number).
@@ -2480,7 +2480,7 @@ Returns the the logarithm of a number, base e (Euler's number).
 ```
 
 </details>
-<details id="log" markdown><summary >
+<details markdown><summary >
 #### <code>__LOG__(value, base=10)</code> {: #log }
 </summary>
 Returns the the logarithm of a number given a base.
@@ -2502,7 +2502,7 @@ Returns the the logarithm of a number given a base.
 ```
 
 </details>
-<details id="log10" markdown><summary >
+<details markdown><summary >
 #### <code>__LOG10__(value)</code> {: #log10 }
 </summary>
 Returns the the logarithm of a number, base 10.
@@ -2529,7 +2529,7 @@ Returns the the logarithm of a number, base 10.
 ```
 
 </details>
-<details id="mod" markdown><summary >
+<details markdown><summary >
 #### <code>__MOD__(dividend, divisor)</code> {: #mod }
 </summary>
 Returns the result of the modulo operator, the remainder after a division operation.
@@ -2556,7 +2556,7 @@ Returns the result of the modulo operator, the remainder after a division operat
 ```
 
 </details>
-<details id="mround" markdown><summary >
+<details markdown><summary >
 #### <code>__MROUND__(value, factor)</code> {: #mround }
 </summary>
 Rounds one number to the nearest integer multiple of another.
@@ -2585,7 +2585,7 @@ ValueError: factor argument invalid
 ```
 
 </details>
-<details id="multinomial" markdown><summary >
+<details markdown><summary >
 #### <code>__MULTINOMIAL__(value1, *more_values)</code> {: #multinomial }
 </summary>
 Returns the factorial of the sum of values divided by the product of the values' factorials.
@@ -2612,7 +2612,7 @@ Returns the factorial of the sum of values divided by the product of the values'
 ```
 
 </details>
-<details id="num" markdown><summary >
+<details markdown><summary >
 #### <code>__NUM__(value)</code> {: #num }
 </summary>
 For a Python floating-point value that's actually an integer, returns a Python integer type.
@@ -2641,7 +2641,7 @@ Numeric Grist column (represented as floats), but when int values are actually e
 ```
 
 </details>
-<details id="odd" markdown><summary >
+<details markdown><summary >
 #### <code>__ODD__(value)</code> {: #odd }
 </summary>
 Rounds a number up to the nearest odd integer.
@@ -2673,7 +2673,7 @@ Rounds a number up to the nearest odd integer.
 ```
 
 </details>
-<details id="pi" markdown><summary >
+<details markdown><summary >
 #### <code>__PI__()</code> {: #pi }
 </summary>
 Returns the value of Pi to 14 decimal places.
@@ -2695,7 +2695,7 @@ Returns the value of Pi to 14 decimal places.
 ```
 
 </details>
-<details id="power" markdown><summary >
+<details markdown><summary >
 #### <code>__POWER__(base, exponent)</code> {: #power }
 </summary>
 Returns a number raised to a power.
@@ -2717,7 +2717,7 @@ Returns a number raised to a power.
 ```
 
 </details>
-<details id="product" markdown><summary >
+<details markdown><summary >
 #### <code>__PRODUCT__(factor1, *more_factors)</code> {: #product }
 </summary>
 Returns the result of multiplying a series of numbers together. Each argument may be a number or
@@ -2739,7 +2739,7 @@ an array.
 4500
 ```
 </details>
-<details id="quotient" markdown><summary >
+<details markdown><summary >
 #### <code>__QUOTIENT__(dividend, divisor)</code> {: #quotient }
 </summary>
 Returns one number divided by another, without the remainder.
@@ -2761,7 +2761,7 @@ Returns one number divided by another, without the remainder.
 ```
 
 </details>
-<details id="radians" markdown><summary >
+<details markdown><summary >
 #### <code>__RADIANS__(angle)</code> {: #radians }
 </summary>
 Converts an angle value in degrees to radians.
@@ -2773,17 +2773,17 @@ Converts an angle value in degrees to radians.
 ```
 
 </details>
-<details id="rand" markdown><summary >
+<details markdown><summary >
 #### <code>__RAND__()</code> {: #rand }
 </summary>
 Returns a random number between 0 inclusive and 1 exclusive.
 </details>
-<details id="randbetween" markdown><summary >
+<details markdown><summary >
 #### <code>__RANDBETWEEN__(low, high)</code> {: #randbetween }
 </summary>
 Returns a uniformly random integer between two values, inclusive.
 </details>
-<details id="roman" markdown><summary >
+<details markdown><summary >
 #### <code>__ROMAN__(number, form_unused=None)</code> {: #roman }
 </summary>
 Formats a number in Roman numerals. The second argument is ignored in this implementation.
@@ -2810,7 +2810,7 @@ Formats a number in Roman numerals. The second argument is ignored in this imple
 ```
 
 </details>
-<details id="round" markdown><summary >
+<details markdown><summary >
 #### <code>__ROUND__(value, places=0)</code> {: #round }
 </summary>
 Rounds a number to a certain number of decimal places,
@@ -2876,7 +2876,7 @@ in the case of a tie, i.e. when the last digit is 5.
 ```
 
 </details>
-<details id="rounddown" markdown><summary >
+<details markdown><summary >
 #### <code>__ROUNDDOWN__(value, places=0)</code> {: #rounddown }
 </summary>
 Rounds a number to a certain number of decimal places, always rounding down towards zero.
@@ -2908,7 +2908,7 @@ Rounds a number to a certain number of decimal places, always rounding down towa
 ```
 
 </details>
-<details id="roundup" markdown><summary >
+<details markdown><summary >
 #### <code>__ROUNDUP__(value, places=0)</code> {: #roundup }
 </summary>
 Rounds a number to a certain number of decimal places, always rounding up away from zero.
@@ -2940,7 +2940,7 @@ Rounds a number to a certain number of decimal places, always rounding up away f
 ```
 
 </details>
-<details id="seriessum" markdown><summary >
+<details markdown><summary >
 #### <code>__SERIESSUM__(x, n, m, a)</code> {: #seriessum }
 </summary>
 Given parameters x, n, m, and a, returns the power series sum a_1*x^n + a_2*x^(n+m)
@@ -2968,7 +2968,7 @@ Given parameters x, n, m, and a, returns the power series sum a_1*x^n + a_2*x^(n
 ```
 
 </details>
-<details id="sign" markdown><summary >
+<details markdown><summary >
 #### <code>__SIGN__(value)</code> {: #sign }
 </summary>
 Given an input number, returns `-1` if it is negative, `1` if positive, and `0` if it is zero.
@@ -2990,7 +2990,7 @@ Given an input number, returns `-1` if it is negative, `1` if positive, and `0` 
 ```
 
 </details>
-<details id="sin" markdown><summary >
+<details markdown><summary >
 #### <code>__SIN__(angle)</code> {: #sin }
 </summary>
 Returns the sine of an angle provided in radians.
@@ -3017,7 +3017,7 @@ Returns the sine of an angle provided in radians.
 ```
 
 </details>
-<details id="sinh" markdown><summary >
+<details markdown><summary >
 #### <code>__SINH__(value)</code> {: #sinh }
 </summary>
 Returns the hyperbolic sine of any real number.
@@ -3029,7 +3029,7 @@ Returns the hyperbolic sine of any real number.
 ```
 
 </details>
-<details id="sqrt" markdown><summary >
+<details markdown><summary >
 #### <code>__SQRT__(value)</code> {: #sqrt }
 </summary>
 Returns the positive square root of a positive number.
@@ -3053,7 +3053,7 @@ ValueError: math domain error
 ```
 
 </details>
-<details id="sqrtpi" markdown><summary >
+<details markdown><summary >
 #### <code>__SQRTPI__(value)</code> {: #sqrtpi }
 </summary>
 Returns the positive square root of the product of Pi and the given positive number.
@@ -3070,14 +3070,14 @@ Returns the positive square root of the product of Pi and the given positive num
 ```
 
 </details>
-<details id="subtotal" markdown><summary class="unimplemented">
+<details>
 #### <code>__SUBTOTAL__(function_code, range1, range2)</code> {: #subtotal }
 </summary>
 Returns a subtotal for a vertical range of cells using a specified aggregation function.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="sum" markdown><summary >
+<details markdown><summary >
 #### <code>__SUM__(value1, *more_values)</code> {: #sum }
 </summary>
 Returns the sum of a series of numbers. Each argument may be a number or an array.
@@ -3099,21 +3099,21 @@ Non-numeric values are ignored.
 52
 ```
 </details>
-<details id="sumif" markdown><summary class="unimplemented">
+<details>
 #### <code>__SUMIF__(records, criterion, sum_range)</code> {: #sumif }
 </summary>
 Returns a conditional sum across a range.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="sumifs" markdown><summary class="unimplemented">
+<details>
 #### <code>__SUMIFS__(sum_range, criteria_range1, criterion1, *args)</code> {: #sumifs }
 </summary>
 Returns the sum of a range depending on multiple criteria.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="sumproduct" markdown><summary >
+<details markdown><summary >
 #### <code>__SUMPRODUCT__(array1, *more_arrays)</code> {: #sumproduct }
 </summary>
 Multiplies corresponding components in two equally-sized arrays,
@@ -3141,14 +3141,14 @@ and returns the sum of those products.
 ```
 
 </details>
-<details id="sumsq" markdown><summary class="unimplemented">
+<details>
 #### <code>__SUMSQ__(value1, value2)</code> {: #sumsq }
 </summary>
 Returns the sum of the squares of a series of numbers and/or cells.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="tan" markdown><summary >
+<details markdown><summary >
 #### <code>__TAN__(angle)</code> {: #tan }
 </summary>
 Returns the tangent of an angle provided in radians.
@@ -3170,7 +3170,7 @@ Returns the tangent of an angle provided in radians.
 ```
 
 </details>
-<details id="tanh" markdown><summary >
+<details markdown><summary >
 #### <code>__TANH__(value)</code> {: #tanh }
 </summary>
 Returns the hyperbolic tangent of any real number.
@@ -3192,7 +3192,7 @@ Returns the hyperbolic tangent of any real number.
 ```
 
 </details>
-<details id="trunc" markdown><summary >
+<details markdown><summary >
 #### <code>__TRUNC__(value, places=0)</code> {: #trunc }
 </summary>
 Truncates a number to a certain number of significant digits by omitting less significant
@@ -3215,7 +3215,7 @@ digits.
 ```
 
 </details>
-<details id="uuid" markdown><summary >
+<details markdown><summary >
 #### <code>__UUID__()</code> {: #uuid }
 </summary>
 Generate a random UUID-formatted string identifier.
@@ -3227,7 +3227,7 @@ formula may get recalculated any time the document is reloaded, producing a diff
 UUID() each time.
 </details>
 ### Schedule
-<details id="schedule" markdown><summary >
+<details markdown><summary >
 #### <code>__SCHEDULE__(schedule, start=None, count=10, end=None)</code> {: #schedule }
 </summary>
 Returns the list of `datetime` objects generated according to the `schedule` string. Starts at
@@ -3350,14 +3350,14 @@ The time zone of `start` determines the time zone of the generated times.
 
 </details>
 ### Stats
-<details id="avedev" markdown><summary class="unimplemented">
+<details>
 #### <code>__AVEDEV__(value1, value2)</code> {: #avedev }
 </summary>
 Calculates the average of the magnitudes of deviations of data from a dataset's mean.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="average" markdown><summary >
+<details markdown><summary >
 #### <code>__AVERAGE__(value, *more_values)</code> {: #average }
 </summary>
 Returns the numerical average value in a dataset, ignoring non-numerical values.
@@ -3389,7 +3389,7 @@ ZeroDivisionError: float division by zero
 ```
 
 </details>
-<details id="averagea" markdown><summary >
+<details markdown><summary >
 #### <code>__AVERAGEA__(value, *more_values)</code> {: #averagea }
 </summary>
 Returns the numerical average value in a dataset, counting non-numerical values as 0.
@@ -3420,21 +3420,21 @@ False as 0.
 ```
 
 </details>
-<details id="averageif" markdown><summary class="unimplemented">
+<details>
 #### <code>__AVERAGEIF__(criteria_range, criterion, average_range=None)</code> {: #averageif }
 </summary>
 Returns the average of a range depending on criteria.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="averageifs" markdown><summary class="unimplemented">
+<details>
 #### <code>__AVERAGEIFS__(average_range, criteria_range1, criterion1, *args)</code> {: #averageifs }
 </summary>
 Returns the average of a range depending on multiple criteria.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="average_weighted" markdown><summary >
+<details markdown><summary >
 #### <code>__AVERAGE_WEIGHTED__(pairs)</code> {: #average_weighted }
 </summary>
 Given a list of (value, weight) pairs, finds the average of the values weighted by the
@@ -3460,7 +3460,7 @@ list of pairs.
 ```
 
 </details>
-<details id="binomdist" markdown><summary class="unimplemented">
+<details>
 #### <code>__BINOMDIST__(num_successes, num_trials, prob_success, cumulative)</code> {: #binomdist }
 </summary>
 Calculates the probability of drawing a certain number of successes (or a maximum number of
@@ -3469,21 +3469,21 @@ certain number of successes, with replacement of draws.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="confidence" markdown><summary class="unimplemented">
+<details>
 #### <code>__CONFIDENCE__(alpha, standard_deviation, pop_size)</code> {: #confidence }
 </summary>
 Calculates the width of half the confidence interval for a normal distribution.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="correl" markdown><summary class="unimplemented">
+<details>
 #### <code>__CORREL__(data_y, data_x)</code> {: #correl }
 </summary>
 Calculates r, the Pearson product-moment correlation coefficient of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="count" markdown><summary >
+<details markdown><summary >
 #### <code>__COUNT__(value, *more_values)</code> {: #count }
 </summary>
 Returns the count of numerical and date/datetime values in a dataset,
@@ -3519,7 +3519,7 @@ and blank values, and text representations of numbers, are ignored.
 ```
 
 </details>
-<details id="counta" markdown><summary >
+<details markdown><summary >
 #### <code>__COUNTA__(value, *more_values)</code> {: #counta }
 </summary>
 Returns the count of all values in a dataset, including non-numerical values.
@@ -3548,35 +3548,35 @@ Each argument may be a value or an array.
 ```
 
 </details>
-<details id="covar" markdown><summary class="unimplemented">
+<details>
 #### <code>__COVAR__(data_y, data_x)</code> {: #covar }
 </summary>
 Calculates the covariance of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="critbinom" markdown><summary class="unimplemented">
+<details>
 #### <code>__CRITBINOM__(num_trials, prob_success, target_prob)</code> {: #critbinom }
 </summary>
 Calculates the smallest value for which the cumulative binomial distribution is greater than or equal to a specified criteria.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="devsq" markdown><summary class="unimplemented">
+<details>
 #### <code>__DEVSQ__(value1, value2)</code> {: #devsq }
 </summary>
 Calculates the sum of squares of deviations based on a sample.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="expondist" markdown><summary class="unimplemented">
+<details>
 #### <code>__EXPONDIST__(x, lambda_, cumulative)</code> {: #expondist }
 </summary>
 Returns the value of the exponential distribution function with a specified lambda at a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="fdist" markdown><summary class="unimplemented">
+<details>
 #### <code>__FDIST__(x, degrees_freedom1, degrees_freedom2)</code> {: #fdist }
 </summary>
 Calculates the right-tailed F probability distribution (degree of diversity) for two data sets
@@ -3585,28 +3585,28 @@ distribution.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="fisher" markdown><summary class="unimplemented">
+<details>
 #### <code>__FISHER__(value)</code> {: #fisher }
 </summary>
 Returns the Fisher transformation of a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="fisherinv" markdown><summary class="unimplemented">
+<details>
 #### <code>__FISHERINV__(value)</code> {: #fisherinv }
 </summary>
 Returns the inverse Fisher transformation of a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="forecast" markdown><summary class="unimplemented">
+<details>
 #### <code>__FORECAST__(x, data_y, data_x)</code> {: #forecast }
 </summary>
 Calculates the expected y-value for a specified x based on a linear regression of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="f_dist" markdown><summary class="unimplemented">
+<details>
 #### <code>__F_DIST__(x, degrees_freedom1, degrees_freedom2, cumulative)</code> {: #f_dist }
 </summary>
 Calculates the left-tailed F probability distribution (degree of diversity) for two data sets
@@ -3615,7 +3615,7 @@ distribution.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="f_dist_rt" markdown><summary class="unimplemented">
+<details>
 #### <code>__F_DIST_RT__(x, degrees_freedom1, degrees_freedom2)</code> {: #f_dist_rt }
 </summary>
 Calculates the right-tailed F probability distribution (degree of diversity) for two data sets
@@ -3624,63 +3624,63 @@ distribution.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="geomean" markdown><summary class="unimplemented">
+<details>
 #### <code>__GEOMEAN__(value1, value2)</code> {: #geomean }
 </summary>
 Calculates the geometric mean of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="harmean" markdown><summary class="unimplemented">
+<details>
 #### <code>__HARMEAN__(value1, value2)</code> {: #harmean }
 </summary>
 Calculates the harmonic mean of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="hypgeomdist" markdown><summary class="unimplemented">
+<details>
 #### <code>__HYPGEOMDIST__(num_successes, num_draws, successes_in_pop, pop_size)</code> {: #hypgeomdist }
 </summary>
 Calculates the probability of drawing a certain number of successes in a certain number of tries given a population of a certain size containing a certain number of successes, without replacement of draws.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="intercept" markdown><summary class="unimplemented">
+<details>
 #### <code>__INTERCEPT__(data_y, data_x)</code> {: #intercept }
 </summary>
 Calculates the y-value at which the line resulting from linear regression of a dataset will intersect the y-axis (x=0).
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="kurt" markdown><summary class="unimplemented">
+<details>
 #### <code>__KURT__(value1, value2)</code> {: #kurt }
 </summary>
 Calculates the kurtosis of a dataset, which describes the shape, and in particular the "peakedness" of that dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="large" markdown><summary class="unimplemented">
+<details>
 #### <code>__LARGE__(data, n)</code> {: #large }
 </summary>
 Returns the nth largest element from a data set, where n is user-defined.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="loginv" markdown><summary class="unimplemented">
+<details>
 #### <code>__LOGINV__(x, mean, standard_deviation)</code> {: #loginv }
 </summary>
 Returns the value of the inverse log-normal cumulative distribution with given mean and standard deviation at a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="lognormdist" markdown><summary class="unimplemented">
+<details>
 #### <code>__LOGNORMDIST__(x, mean, standard_deviation)</code> {: #lognormdist }
 </summary>
 Returns the value of the log-normal cumulative distribution with given mean and standard deviation at a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="max" markdown><summary >
+<details markdown><summary >
 #### <code>__MAX__(value, *more_values)</code> {: #max }
 </summary>
 Returns the maximum value in a dataset, ignoring values other than numbers and dates/datetimes.
@@ -3731,7 +3731,7 @@ datetime.date(2015, 1, 2)
 ```
 
 </details>
-<details id="maxa" markdown><summary >
+<details markdown><summary >
 #### <code>__MAXA__(value, *more_values)</code> {: #maxa }
 </summary>
 Returns the maximum numeric value in a dataset.
@@ -3767,7 +3767,7 @@ False as 0. Returns 0 if the arguments contain no numbers.
 ```
 
 </details>
-<details id="median" markdown><summary >
+<details markdown><summary >
 #### <code>__MEDIAN__(value, *more_values)</code> {: #median }
 </summary>
 Returns the median value in a numeric dataset, ignoring non-numerical values.
@@ -3810,7 +3810,7 @@ ValueError: MEDIAN requires at least one number
 ```
 
 </details>
-<details id="min" markdown><summary >
+<details markdown><summary >
 #### <code>__MIN__(value, *more_values)</code> {: #min }
 </summary>
 Returns the minimum value in a dataset, ignoring values other than numbers and dates/datetimes.
@@ -3861,7 +3861,7 @@ datetime.datetime(2015, 1, 1, 12, 34, 56)
 ```
 
 </details>
-<details id="mina" markdown><summary >
+<details markdown><summary >
 #### <code>__MINA__(value, *more_values)</code> {: #mina }
 </summary>
 Returns the minimum numeric value in a dataset.
@@ -3897,21 +3897,21 @@ False as 0. Returns 0 if the arguments contain no numbers.
 ```
 
 </details>
-<details id="mode" markdown><summary class="unimplemented">
+<details>
 #### <code>__MODE__(value1, value2)</code> {: #mode }
 </summary>
 Returns the most commonly occurring value in a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="negbinomdist" markdown><summary class="unimplemented">
+<details>
 #### <code>__NEGBINOMDIST__(num_failures, num_successes, prob_success)</code> {: #negbinomdist }
 </summary>
 Calculates the probability of drawing a certain number of failures before a certain number of successes given a probability of success in independent trials.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="normdist" markdown><summary class="unimplemented">
+<details>
 #### <code>__NORMDIST__(x, mean, standard_deviation, cumulative)</code> {: #normdist }
 </summary>
 Returns the value of the normal distribution function (or normal cumulative distribution
@@ -3919,70 +3919,70 @@ function) for a specified value, mean, and standard deviation.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="norminv" markdown><summary class="unimplemented">
+<details>
 #### <code>__NORMINV__(x, mean, standard_deviation)</code> {: #norminv }
 </summary>
 Returns the value of the inverse normal distribution function for a specified value, mean, and standard deviation.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="normsdist" markdown><summary class="unimplemented">
+<details>
 #### <code>__NORMSDIST__(x)</code> {: #normsdist }
 </summary>
 Returns the value of the standard normal cumulative distribution function for a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="normsinv" markdown><summary class="unimplemented">
+<details>
 #### <code>__NORMSINV__(x)</code> {: #normsinv }
 </summary>
 Returns the value of the inverse standard normal distribution function for a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="pearson" markdown><summary class="unimplemented">
+<details>
 #### <code>__PEARSON__(data_y, data_x)</code> {: #pearson }
 </summary>
 Calculates r, the Pearson product-moment correlation coefficient of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="percentile" markdown><summary class="unimplemented">
+<details>
 #### <code>__PERCENTILE__(data, percentile)</code> {: #percentile }
 </summary>
 Returns the value at a given percentile of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="percentrank" markdown><summary class="unimplemented">
+<details>
 #### <code>__PERCENTRANK__(data, value, significant_digits=None)</code> {: #percentrank }
 </summary>
 Returns the percentage rank (percentile) of a specified value in a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="percentrank_exc" markdown><summary class="unimplemented">
+<details>
 #### <code>__PERCENTRANK_EXC__(data, value, significant_digits=None)</code> {: #percentrank_exc }
 </summary>
 Returns the percentage rank (percentile) from 0 to 1 exclusive of a specified value in a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="percentrank_inc" markdown><summary class="unimplemented">
+<details>
 #### <code>__PERCENTRANK_INC__(data, value, significant_digits=None)</code> {: #percentrank_inc }
 </summary>
 Returns the percentage rank (percentile) from 0 to 1 inclusive of a specified value in a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="permut" markdown><summary class="unimplemented">
+<details>
 #### <code>__PERMUT__(n, k)</code> {: #permut }
 </summary>
 Returns the number of ways to choose some number of objects from a pool of a given size of objects, considering order.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="poisson" markdown><summary class="unimplemented">
+<details>
 #### <code>__POISSON__(x, mean, cumulative)</code> {: #poisson }
 </summary>
 Returns the value of the Poisson distribution function (or Poisson cumulative distribution
@@ -3990,70 +3990,70 @@ function) for a specified value and mean.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="prob" markdown><summary class="unimplemented">
+<details>
 #### <code>__PROB__(data, probabilities, low_limit, high_limit=None)</code> {: #prob }
 </summary>
 Given a set of values and corresponding probabilities, calculates the probability that a value chosen at random falls between two limits.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="quartile" markdown><summary class="unimplemented">
+<details>
 #### <code>__QUARTILE__(data, quartile_number)</code> {: #quartile }
 </summary>
 Returns a value nearest to a specified quartile of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="rank_avg" markdown><summary class="unimplemented">
+<details>
 #### <code>__RANK_AVG__(value, data, is_ascending=None)</code> {: #rank_avg }
 </summary>
 Returns the rank of a specified value in a dataset. If there is more than one entry of the same value in the dataset, the average rank of the entries will be returned.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="rank_eq" markdown><summary class="unimplemented">
+<details>
 #### <code>__RANK_EQ__(value, data, is_ascending=None)</code> {: #rank_eq }
 </summary>
 Returns the rank of a specified value in a dataset. If there is more than one entry of the same value in the dataset, the top rank of the entries will be returned.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="rsq" markdown><summary class="unimplemented">
+<details>
 #### <code>__RSQ__(data_y, data_x)</code> {: #rsq }
 </summary>
 Calculates the square of r, the Pearson product-moment correlation coefficient of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="skew" markdown><summary class="unimplemented">
+<details>
 #### <code>__SKEW__(value1, value2)</code> {: #skew }
 </summary>
 Calculates the skewness of a dataset, which describes the symmetry of that dataset about the mean.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="slope" markdown><summary class="unimplemented">
+<details>
 #### <code>__SLOPE__(data_y, data_x)</code> {: #slope }
 </summary>
 Calculates the slope of the line resulting from linear regression of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="small" markdown><summary class="unimplemented">
+<details>
 #### <code>__SMALL__(data, n)</code> {: #small }
 </summary>
 Returns the nth smallest element from a data set, where n is user-defined.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="standardize" markdown><summary class="unimplemented">
+<details>
 #### <code>__STANDARDIZE__(value, mean, standard_deviation)</code> {: #standardize }
 </summary>
 Calculates the normalized equivalent of a random variable given mean and standard deviation of the distribution.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="stdev" markdown><summary >
+<details markdown><summary >
 #### <code>__STDEV__(value, *more_values)</code> {: #stdev }
 </summary>
 Calculates the standard deviation based on a sample, ignoring non-numerical values.
@@ -4087,7 +4087,7 @@ ZeroDivisionError: float division by zero
 ```
 
 </details>
-<details id="stdeva" markdown><summary >
+<details markdown><summary >
 #### <code>__STDEVA__(value, *more_values)</code> {: #stdeva }
 </summary>
 Calculates the standard deviation based on a sample, setting text to the value `0`.
@@ -4121,7 +4121,7 @@ ZeroDivisionError: float division by zero
 ```
 
 </details>
-<details id="stdevp" markdown><summary >
+<details markdown><summary >
 #### <code>__STDEVP__(value, *more_values)</code> {: #stdevp }
 </summary>
 Calculates the standard deviation based on an entire population, ignoring non-numerical values.
@@ -4153,7 +4153,7 @@ Calculates the standard deviation based on an entire population, ignoring non-nu
 ```
 
 </details>
-<details id="stdevpa" markdown><summary >
+<details markdown><summary >
 #### <code>__STDEVPA__(value, *more_values)</code> {: #stdevpa }
 </summary>
 Calculates the standard deviation based on an entire population, setting text to the value `0`.
@@ -4185,84 +4185,84 @@ Calculates the standard deviation based on an entire population, setting text to
 ```
 
 </details>
-<details id="steyx" markdown><summary class="unimplemented">
+<details>
 #### <code>__STEYX__(data_y, data_x)</code> {: #steyx }
 </summary>
 Calculates the standard error of the predicted y-value for each x in the regression of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="tdist" markdown><summary class="unimplemented">
+<details>
 #### <code>__TDIST__(x, degrees_freedom, tails)</code> {: #tdist }
 </summary>
 Calculates the probability for Student's t-distribution with a given input (x).
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="tinv" markdown><summary class="unimplemented">
+<details>
 #### <code>__TINV__(probability, degrees_freedom)</code> {: #tinv }
 </summary>
 Calculates the inverse of the two-tailed TDIST function.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="trimmean" markdown><summary class="unimplemented">
+<details>
 #### <code>__TRIMMEAN__(data, exclude_proportion)</code> {: #trimmean }
 </summary>
 Calculates the mean of a dataset excluding some proportion of data from the high and low ends of the dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="ttest" markdown><summary class="unimplemented">
+<details>
 #### <code>__TTEST__(range1, range2, tails, type)</code> {: #ttest }
 </summary>
 Returns the probability associated with t-test. Determines whether two samples are likely to have come from the same two underlying populations that have the same mean.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="t_inv" markdown><summary class="unimplemented">
+<details>
 #### <code>__T_INV__(probability, degrees_freedom)</code> {: #t_inv }
 </summary>
 Calculates the negative inverse of the one-tailed TDIST function.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="t_inv_2t" markdown><summary class="unimplemented">
+<details>
 #### <code>__T_INV_2T__(probability, degrees_freedom)</code> {: #t_inv_2t }
 </summary>
 Calculates the inverse of the two-tailed TDIST function.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="var" markdown><summary class="unimplemented">
+<details>
 #### <code>__VAR__(value1, value2)</code> {: #var }
 </summary>
 Calculates the variance based on a sample.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="vara" markdown><summary class="unimplemented">
+<details>
 #### <code>__VARA__(value1, value2)</code> {: #vara }
 </summary>
 Calculates an estimate of variance based on a sample, setting text to the value `0`.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="varp" markdown><summary class="unimplemented">
+<details>
 #### <code>__VARP__(value1, value2)</code> {: #varp }
 </summary>
 Calculates the variance based on an entire population.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="varpa" markdown><summary class="unimplemented">
+<details>
 #### <code>__VARPA__(value1, value2)</code> {: #varpa }
 </summary>
 Calculates the variance based on an entire population, setting text to the value `0`.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="weibull" markdown><summary class="unimplemented">
+<details>
 #### <code>__WEIBULL__(x, shape, scale, cumulative)</code> {: #weibull }
 </summary>
 Returns the value of the Weibull distribution function (or Weibull cumulative distribution
@@ -4270,7 +4270,7 @@ function) for a specified shape and scale.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="ztest" markdown><summary class="unimplemented">
+<details>
 #### <code>__ZTEST__(data, value, standard_deviation)</code> {: #ztest }
 </summary>
 Returns the two-tailed P-value of a Z-test with standard distribution.
@@ -4278,7 +4278,7 @@ Returns the two-tailed P-value of a Z-test with standard distribution.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 ### Text
-<details id="char" markdown><summary >
+<details markdown><summary >
 #### <code>__CHAR__(table_number)</code> {: #char }
 </summary>
 Convert a number into a character according to the current Unicode table.
@@ -4296,7 +4296,7 @@ u'!'
 ```
 
 </details>
-<details id="clean" markdown><summary >
+<details markdown><summary >
 #### <code>__CLEAN__(text)</code> {: #clean }
 </summary>
 Returns the text with the non-printable characters removed.
@@ -4311,7 +4311,7 @@ u'Monthly report'
 ```
 
 </details>
-<details id="code" markdown><summary >
+<details markdown><summary >
 #### <code>__CODE__(string)</code> {: #code }
 </summary>
 Returns the numeric Unicode map value of the first character in the string provided.
@@ -4334,7 +4334,7 @@ Same as `ord(string[0])`.
 ```
 
 </details>
-<details id="concat" markdown><summary >
+<details markdown><summary >
 #### <code>__CONCAT__(string, *more_strings)</code> {: #concat }
 </summary>
 Joins together any number of text strings into one string. Also available under the name
@@ -4367,7 +4367,7 @@ u'0abc'
 ```
 
 </details>
-<details id="concatenate" markdown><summary >
+<details markdown><summary >
 #### <code>__CONCATENATE__(string, *more_strings)</code> {: #concatenate }
 </summary>
 Joins together any number of text strings into one string. Also available under the name
@@ -4410,7 +4410,7 @@ u'0abc'
 ```
 
 </details>
-<details id="dollar" markdown><summary >
+<details markdown><summary >
 #### <code>__DOLLAR__(number, decimals=2)</code> {: #dollar }
 </summary>
 Formats a number into a formatted dollar amount, with decimals rounded to the specified place (.
@@ -4453,7 +4453,7 @@ If decimals value is omitted, it defaults to 2.
 ```
 
 </details>
-<details id="exact" markdown><summary >
+<details markdown><summary >
 #### <code>__EXACT__(string1, string2)</code> {: #exact }
 </summary>
 Tests whether two strings are identical. Same as `string2 == string2`.
@@ -4475,7 +4475,7 @@ False
 ```
 
 </details>
-<details id="find" markdown><summary >
+<details markdown><summary >
 #### <code>__FIND__(find_text, within_text, start_num=1)</code> {: #find }
 </summary>
 Returns the position at which a string is first found within text.
@@ -4532,7 +4532,7 @@ ValueError: substring not found
 ```
 
 </details>
-<details id="fixed" markdown><summary >
+<details markdown><summary >
 #### <code>__FIXED__(number, decimals=2, no_commas=False)</code> {: #fixed }
 </summary>
 Formats a number with a fixed number of decimal places (2 by default), and commas.
@@ -4580,7 +4580,7 @@ If no_commas is True, then omits the commas.
 ```
 
 </details>
-<details id="left" markdown><summary >
+<details markdown><summary >
 #### <code>__LEFT__(string, num_chars=1)</code> {: #left }
 </summary>
 Returns a substring of length num_chars from the beginning of the given string. If num_chars is
@@ -4605,7 +4605,7 @@ ValueError: num_chars invalid
 ```
 
 </details>
-<details id="len" markdown><summary >
+<details markdown><summary >
 #### <code>__LEN__(text)</code> {: #len }
 </summary>
 Returns the number of characters in a text string, or the number of items in a list. Same as
@@ -4629,7 +4629,7 @@ See [Record Set](#recordset) for an example of using `len` on a list of records.
 ```
 
 </details>
-<details id="lower" markdown><summary >
+<details markdown><summary >
 #### <code>__LOWER__(text)</code> {: #lower }
 </summary>
 Converts a specified string to lowercase. Same as `text.lower()`.
@@ -4646,7 +4646,7 @@ Converts a specified string to lowercase. Same as `text.lower()`.
 ```
 
 </details>
-<details id="mid" markdown><summary >
+<details markdown><summary >
 #### <code>__MID__(text, start_num, num_chars)</code> {: #mid }
 </summary>
 Returns a segment of a string, starting at start_num. The first character in text has
@@ -4676,7 +4676,7 @@ ValueError: start_num invalid
 ```
 
 </details>
-<details id="phone_format" markdown><summary >
+<details markdown><summary >
 #### <code>__PHONE_FORMAT__(value, country=None, format=None)</code> {: #phone_format }
 </summary>
 Formats a phone number.
@@ -4780,7 +4780,7 @@ TypeError: Phone number must be a text value. If formatting a value from a Numer
 ```
 
 </details>
-<details id="proper" markdown><summary >
+<details markdown><summary >
 #### <code>__PROPER__(text)</code> {: #proper }
 </summary>
 Capitalizes each word in a specified string. It converts the first letter of each word to
@@ -4803,7 +4803,7 @@ uppercase, and all other letters to lowercase. Same as `text.title()`.
 ```
 
 </details>
-<details id="regexextract" markdown><summary >
+<details markdown><summary >
 #### <code>__REGEXEXTRACT__(text, regular_expression)</code> {: #regexextract }
 </summary>
 Extracts the first part of text that matches regular_expression.
@@ -4834,7 +4834,7 @@ ValueError: REGEXEXTRACT text does not match
 ```
 
 </details>
-<details id="regexmatch" markdown><summary >
+<details markdown><summary >
 #### <code>__REGEXMATCH__(text, regular_expression)</code> {: #regexmatch }
 </summary>
 Returns whether a piece of text matches a regular expression.
@@ -4866,7 +4866,7 @@ False
 ```
 
 </details>
-<details id="regexreplace" markdown><summary >
+<details markdown><summary >
 #### <code>__REGEXREPLACE__(text, regular_expression, replacement)</code> {: #regexreplace }
 </summary>
 Replaces all parts of text matching the given regular expression with replacement text.
@@ -4898,7 +4898,7 @@ Replaces all parts of text matching the given regular expression with replacemen
 ```
 
 </details>
-<details id="replace" markdown><summary >
+<details markdown><summary >
 #### <code>__REPLACE__(text, position, length, new_text)</code> {: #replace }
 </summary>
 Replaces part of a text string with a different text string. Position is counted from 1.
@@ -4932,7 +4932,7 @@ ValueError: position invalid
 ```
 
 </details>
-<details id="rept" markdown><summary >
+<details markdown><summary >
 #### <code>__REPT__(text, number_times)</code> {: #rept }
 </summary>
 Returns specified text repeated a number of times. Same as `text * number_times`.
@@ -4976,7 +4976,7 @@ ValueError: number_times invalid
 ```
 
 </details>
-<details id="right" markdown><summary >
+<details markdown><summary >
 #### <code>__RIGHT__(string, num_chars=1)</code> {: #right }
 </summary>
 Returns a substring of length num_chars from the end of a specified string. If num_chars is
@@ -5006,7 +5006,7 @@ ValueError: num_chars invalid
 ```
 
 </details>
-<details id="search" markdown><summary >
+<details markdown><summary >
 #### <code>__SEARCH__(find_text, within_text, start_num=1)</code> {: #search }
 </summary>
 Returns the position at which a string is first found within text, ignoring case.
@@ -5048,7 +5048,7 @@ If find_text is not found, or start_num is invalid, raises ValueError.
 ```
 
 </details>
-<details id="substitute" markdown><summary >
+<details markdown><summary >
 #### <code>__SUBSTITUTE__(text, old_text, new_text, instance_num=None)</code> {: #substitute }
 </summary>
 Replaces existing text with new text in a string. It is useful when you know the substring of
@@ -5075,7 +5075,7 @@ u'Quarter 2, 2008'
 u'Quarter 1, 2012'
 ```
 </details>
-<details id="t" markdown><summary >
+<details markdown><summary >
 #### <code>__T__(value)</code> {: #t }
 </summary>
 Returns value if value is text, or the empty string when value is not text.
@@ -5117,7 +5117,7 @@ u''
 ```
 
 </details>
-<details id="tasteme" markdown><summary >
+<details markdown><summary >
 #### <code>__TASTEME__(food)</code> {: #tasteme }
 </summary>
 For any given piece of text, decides if it is tasty or not.
@@ -5138,7 +5138,7 @@ False
 ```
 
 </details>
-<details id="text" markdown><summary class="unimplemented">
+<details>
 #### <code>__TEXT__(number, format_type)</code> {: #text }
 </summary>
 Converts a number into text according to a specified format. It is not yet implemented in
@@ -5147,7 +5147,7 @@ optionally format() to specify the number format.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details id="trim" markdown><summary >
+<details markdown><summary >
 #### <code>__TRIM__(text)</code> {: #trim }
 </summary>
 Removes all spaces from text except for single spaces between words. Note that TRIM does not
@@ -5165,7 +5165,7 @@ remove other whitespace such as tab or newline characters.
 ```
 
 </details>
-<details id="upper" markdown><summary >
+<details markdown><summary >
 #### <code>__UPPER__(text)</code> {: #upper }
 </summary>
 Converts a specified string to uppercase. Same as `text.upper()`.
@@ -5182,7 +5182,7 @@ Converts a specified string to uppercase. Same as `text.upper()`.
 ```
 
 </details>
-<details id="value" markdown><summary >
+<details markdown><summary >
 #### <code>__VALUE__(text)</code> {: #value }
 </summary>
 Converts a string in accepted date, time or number formats into a number or date.

--- a/help/en/docs/functions.md
+++ b/help/en/docs/functions.md
@@ -44,7 +44,7 @@ Python (see [Python documentation](https://docs.python.org/3.11/)). Here are som
 <!-- BEGIN mkpydocs docs -->
 ### Grist
 <details markdown><summary >
-#### <code>class __Record__</code> {: #record }
+#### <code>class __Record__</code> {: #record data-toc-label="Record" }
 </summary>
 A Record represents a record of data. It is the primary means of accessing values in formulas. A
 Record for a particular table has a property for each data and formula column in the table.
@@ -67,7 +67,7 @@ def Name_Length(rec, table):
 Access the field named "Field" of the current record. E.g. `$First_Name` or `rec.First_Name`.
 </details>
 <details markdown><summary >
-#### <code>__$group__</code> {: #_group }
+#### <code>__$group__</code> {: #_group data-toc-label="$group" }
 </summary>
 In a [summary table](summary-tables.md), `$group` is a special field
 containing the list of Records that are summarized by the current summary line.  E.g. the
@@ -84,7 +84,7 @@ sum(r.Shares * r.Price for r in $group)   # Sum of shares * price products
 ```
 </details>
 <details markdown><summary >
-#### <code>class __RecordSet__</code> {: #recordset }
+#### <code>class __RecordSet__</code> {: #recordset data-toc-label="RecordSet" }
 </summary>
 A RecordSet represents a collection of records, as returned by `Table.lookupRecords()` or
 `$group` property in summary views.
@@ -105,7 +105,7 @@ min(Tasks.lookupRecords(Owner="Bob").DueDate)
 You can get the number of records in a RecordSet using `len`, e.g. `len($group)`.
 </details>
 <details markdown><summary >
-#### <code>RecordSet.**find.\***(value)</code> {: #find_ data-toc-label="RecordSet.find" }
+#### <code>RecordSet.**find.\***(value)</code> {: #find_ data-toc-label="find.*" }
 </summary>
 A set of methods for finding values in sorted sets of records, as returned by
 [`lookupRecords`](#lookuprecords). For example:
@@ -151,7 +151,7 @@ return rate.Hourly_Rate
 Note that this is also much faster when there are many rates for the same Person and Role.
 </details>
 <details markdown><summary >
-#### <code>class __UserTable__</code> {: #usertable }
+#### <code>class __UserTable__</code> {: #usertable data-toc-label="UserTable" }
 </summary>
 Each data table in the document is represented in the code by an instance of `UserTable` class.
 These names are always capitalized. A UserTable provides access to all the records in the table,
@@ -160,7 +160,7 @@ as well as methods to look up particular records.
 Every table in the document is available to all formulas.
 </details>
 <details markdown><summary >
-#### <code>UserTable.__all__</code> {: #all }
+#### <code>UserTable.__all__</code> {: #all data-toc-label="all" }
 </summary>
 The list of all the records in this table.
 
@@ -175,7 +175,7 @@ sum(r.Population for r in Countries.all)
 ```
 </details>
 <details markdown><summary >
-#### <code>UserTable.__lookupOne__(Field_In_Lookup_Table=value, ...)</code> {: #lookupone data-toc-label="UserTable.lookupOne" }
+#### <code>UserTable.__lookupOne__(Field_In_Lookup_Table=value, ...)</code> {: #lookupone data-toc-label="lookupOne" }
 </summary>
 Returns a [Record](#record) matching the given field=value arguments. The value may be any
 expression,
@@ -204,7 +204,7 @@ Rates.lookupOne(Person=$id, order_by="-Date")      # Rate with the latest Date.
 ```
 </details>
 <details markdown><summary >
-#### <code>UserTable.__lookupRecords__(Field_In_Lookup_Table=value, ...)</code> {: #lookuprecords_2 data-toc-label="UserTable.lookupRecords" }
+#### <code>UserTable.__lookupRecords__(Field_In_Lookup_Table=value, ...)</code> {: #lookuprecords data-toc-label="lookupRecords" }
 </summary>
 Returns a [RecordSet](#recordset) matching the given field=value arguments. The value may be
 any expression,
@@ -998,14 +998,14 @@ Fraction between same dates, using the Actual/365 basis argument. Uses a 365 day
 ```
 </details>
 ### Info
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__CELL__(info_type, reference)</code> {: #cell data-toc-label="CELL" }
 </summary>
 Returns the requested information about the specified cell. This is not implemented in Grist
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__ISBLANK__(value)</code> {: #isblank data-toc-label="ISBLANK" }
 </summary>
 Returns whether a value refers to an empty cell. It isn't implemented in Grist. To check for an
@@ -1435,13 +1435,13 @@ RECORD(People.lookupOne(First_Name="Alice"))
 RECORD(People.lookupRecords(Department="HR"))
 ```
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__REQUEST__(url, params=None, headers=None, method='GET', data=None, json=None)</code> {: #request data-toc-label="REQUEST" }
 </summary>
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__TYPE__(value)</code> {: #type data-toc-label="TYPE" }
 </summary>
 Returns a number associated with the type of data passed into the function. This is not
@@ -1644,7 +1644,7 @@ True
 </details>
 ### Lookup
 <details markdown><summary >
-#### <code>UserTable.__lookupOne__(Field_In_Lookup_Table=value, ...)</code> {: #lookupone_2 data-toc-label="UserTable.lookupOne" }
+#### <code>UserTable.__lookupOne__(Field_In_Lookup_Table=value, ...)</code> {: #lookupone_2 data-toc-label="lookupOne" }
 </summary>
 Returns a [Record](#record) matching the given field=value arguments. The value may be any
 expression,
@@ -1673,7 +1673,7 @@ Rates.lookupOne(Person=$id, order_by="-Date")      # Rate with the latest Date.
 ```
 </details>
 <details markdown><summary >
-#### <code>UserTable.__lookupRecords__(Field_In_Lookup_Table=value, ...)</code> {: #lookuprecords data-toc-label="UserTable.lookupRecords" }
+#### <code>UserTable.__lookupRecords__(Field_In_Lookup_Table=value, ...)</code> {: #lookuprecords_2 data-toc-label="lookupRecords" }
 </summary>
 Returns a [RecordSet](#recordset) matching the given field=value arguments. The value may be
 any expression,
@@ -1715,28 +1715,28 @@ value.
 
 Learn more about [lookupRecords](references-lookups.md#lookuprecords).
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__ADDRESS__(row, column, absolute_relative_mode, use_a1_notation, sheet)</code> {: #address data-toc-label="ADDRESS" }
 </summary>
 Returns a cell reference as a string.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__CHOOSE__(index, choice1, choice2)</code> {: #choose data-toc-label="CHOOSE" }
 </summary>
 Returns an element from a list of choices based on index.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__COLUMN__(cell_reference=None)</code> {: #column data-toc-label="COLUMN" }
 </summary>
 Returns the column number of a specified cell, with `A=1`.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__COLUMNS__(range)</code> {: #columns data-toc-label="COLUMNS" }
 </summary>
 Returns the number of columns in a specified array or range.
@@ -1773,70 +1773,70 @@ For example, given this formula:
 If `g` is `''` (i.e. equal to `match_empty`) then the column `genre` in the returned records
 will either be an empty list (or other container) or a list containing `g` as usual.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__GETPIVOTDATA__(value_name, any_pivot_table_cell, original_column_1, pivot_item_1=None, *args)</code> {: #getpivotdata data-toc-label="GETPIVOTDATA" }
 </summary>
 Extracts an aggregated value from a pivot table that corresponds to the specified row and column headings.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__HLOOKUP__(search_key, range, index, is_sorted)</code> {: #hlookup data-toc-label="HLOOKUP" }
 </summary>
 Horizontal lookup. Searches across the first row of a range for a key and returns the value of a specified cell in the column found.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__HYPERLINK__(url, link_label)</code> {: #hyperlink data-toc-label="HYPERLINK" }
 </summary>
 Creates a hyperlink inside a cell.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__INDEX__(reference, row, column)</code> {: #index data-toc-label="INDEX" }
 </summary>
 Returns the content of a cell, specified by row and column offset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__INDIRECT__(cell_reference_as_string)</code> {: #indirect data-toc-label="INDIRECT" }
 </summary>
 Returns a cell reference specified by a string.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__LOOKUP__(search_key, search_range_or_search_result_array, result_range=None)</code> {: #lookup data-toc-label="LOOKUP" }
 </summary>
 Looks through a row or column for a key and returns the value of the cell in a result range located in the same position as the search row or column.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__MATCH__(search_key, range, search_type)</code> {: #match data-toc-label="MATCH" }
 </summary>
 Returns the relative position of an item in a range that matches a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__OFFSET__(cell_reference, offset_rows, offset_columns, height, width)</code> {: #offset data-toc-label="OFFSET" }
 </summary>
 Returns a range reference shifted a specified number of rows and columns from a starting cell reference.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__ROW__(cell_reference)</code> {: #row data-toc-label="ROW" }
 </summary>
 Returns the row number of a specified cell.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__ROWS__(range)</code> {: #rows data-toc-label="ROWS" }
 </summary>
 Returns the number of rows in a specified array or range.
@@ -3070,7 +3070,7 @@ Returns the positive square root of the product of Pi and the given positive num
 ```
 
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__SUBTOTAL__(function_code, range1, range2)</code> {: #subtotal data-toc-label="SUBTOTAL" }
 </summary>
 Returns a subtotal for a vertical range of cells using a specified aggregation function.
@@ -3099,14 +3099,14 @@ Non-numeric values are ignored.
 52
 ```
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__SUMIF__(records, criterion, sum_range)</code> {: #sumif data-toc-label="SUMIF" }
 </summary>
 Returns a conditional sum across a range.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__SUMIFS__(sum_range, criteria_range1, criterion1, *args)</code> {: #sumifs data-toc-label="SUMIFS" }
 </summary>
 Returns the sum of a range depending on multiple criteria.
@@ -3141,7 +3141,7 @@ and returns the sum of those products.
 ```
 
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__SUMSQ__(value1, value2)</code> {: #sumsq data-toc-label="SUMSQ" }
 </summary>
 Returns the sum of the squares of a series of numbers and/or cells.
@@ -3350,7 +3350,7 @@ The time zone of `start` determines the time zone of the generated times.
 
 </details>
 ### Stats
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__AVEDEV__(value1, value2)</code> {: #avedev data-toc-label="AVEDEV" }
 </summary>
 Calculates the average of the magnitudes of deviations of data from a dataset's mean.
@@ -3420,14 +3420,14 @@ False as 0.
 ```
 
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__AVERAGEIF__(criteria_range, criterion, average_range=None)</code> {: #averageif data-toc-label="AVERAGEIF" }
 </summary>
 Returns the average of a range depending on criteria.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__AVERAGEIFS__(average_range, criteria_range1, criterion1, *args)</code> {: #averageifs data-toc-label="AVERAGEIFS" }
 </summary>
 Returns the average of a range depending on multiple criteria.
@@ -3460,7 +3460,7 @@ list of pairs.
 ```
 
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__BINOMDIST__(num_successes, num_trials, prob_success, cumulative)</code> {: #binomdist data-toc-label="BINOMDIST" }
 </summary>
 Calculates the probability of drawing a certain number of successes (or a maximum number of
@@ -3469,14 +3469,14 @@ certain number of successes, with replacement of draws.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__CONFIDENCE__(alpha, standard_deviation, pop_size)</code> {: #confidence data-toc-label="CONFIDENCE" }
 </summary>
 Calculates the width of half the confidence interval for a normal distribution.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__CORREL__(data_y, data_x)</code> {: #correl data-toc-label="CORREL" }
 </summary>
 Calculates r, the Pearson product-moment correlation coefficient of a dataset.
@@ -3548,35 +3548,35 @@ Each argument may be a value or an array.
 ```
 
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__COVAR__(data_y, data_x)</code> {: #covar data-toc-label="COVAR" }
 </summary>
 Calculates the covariance of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__CRITBINOM__(num_trials, prob_success, target_prob)</code> {: #critbinom data-toc-label="CRITBINOM" }
 </summary>
 Calculates the smallest value for which the cumulative binomial distribution is greater than or equal to a specified criteria.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__DEVSQ__(value1, value2)</code> {: #devsq data-toc-label="DEVSQ" }
 </summary>
 Calculates the sum of squares of deviations based on a sample.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__EXPONDIST__(x, lambda_, cumulative)</code> {: #expondist data-toc-label="EXPONDIST" }
 </summary>
 Returns the value of the exponential distribution function with a specified lambda at a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__FDIST__(x, degrees_freedom1, degrees_freedom2)</code> {: #fdist data-toc-label="FDIST" }
 </summary>
 Calculates the right-tailed F probability distribution (degree of diversity) for two data sets
@@ -3585,28 +3585,28 @@ distribution.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__FISHER__(value)</code> {: #fisher data-toc-label="FISHER" }
 </summary>
 Returns the Fisher transformation of a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__FISHERINV__(value)</code> {: #fisherinv data-toc-label="FISHERINV" }
 </summary>
 Returns the inverse Fisher transformation of a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__FORECAST__(x, data_y, data_x)</code> {: #forecast data-toc-label="FORECAST" }
 </summary>
 Calculates the expected y-value for a specified x based on a linear regression of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__F_DIST__(x, degrees_freedom1, degrees_freedom2, cumulative)</code> {: #f_dist data-toc-label="F_DIST" }
 </summary>
 Calculates the left-tailed F probability distribution (degree of diversity) for two data sets
@@ -3615,7 +3615,7 @@ distribution.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__F_DIST_RT__(x, degrees_freedom1, degrees_freedom2)</code> {: #f_dist_rt data-toc-label="F_DIST_RT" }
 </summary>
 Calculates the right-tailed F probability distribution (degree of diversity) for two data sets
@@ -3624,56 +3624,56 @@ distribution.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__GEOMEAN__(value1, value2)</code> {: #geomean data-toc-label="GEOMEAN" }
 </summary>
 Calculates the geometric mean of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__HARMEAN__(value1, value2)</code> {: #harmean data-toc-label="HARMEAN" }
 </summary>
 Calculates the harmonic mean of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__HYPGEOMDIST__(num_successes, num_draws, successes_in_pop, pop_size)</code> {: #hypgeomdist data-toc-label="HYPGEOMDIST" }
 </summary>
 Calculates the probability of drawing a certain number of successes in a certain number of tries given a population of a certain size containing a certain number of successes, without replacement of draws.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__INTERCEPT__(data_y, data_x)</code> {: #intercept data-toc-label="INTERCEPT" }
 </summary>
 Calculates the y-value at which the line resulting from linear regression of a dataset will intersect the y-axis (x=0).
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__KURT__(value1, value2)</code> {: #kurt data-toc-label="KURT" }
 </summary>
 Calculates the kurtosis of a dataset, which describes the shape, and in particular the "peakedness" of that dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__LARGE__(data, n)</code> {: #large data-toc-label="LARGE" }
 </summary>
 Returns the nth largest element from a data set, where n is user-defined.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__LOGINV__(x, mean, standard_deviation)</code> {: #loginv data-toc-label="LOGINV" }
 </summary>
 Returns the value of the inverse log-normal cumulative distribution with given mean and standard deviation at a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__LOGNORMDIST__(x, mean, standard_deviation)</code> {: #lognormdist data-toc-label="LOGNORMDIST" }
 </summary>
 Returns the value of the log-normal cumulative distribution with given mean and standard deviation at a specified value.
@@ -3897,21 +3897,21 @@ False as 0. Returns 0 if the arguments contain no numbers.
 ```
 
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__MODE__(value1, value2)</code> {: #mode data-toc-label="MODE" }
 </summary>
 Returns the most commonly occurring value in a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__NEGBINOMDIST__(num_failures, num_successes, prob_success)</code> {: #negbinomdist data-toc-label="NEGBINOMDIST" }
 </summary>
 Calculates the probability of drawing a certain number of failures before a certain number of successes given a probability of success in independent trials.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__NORMDIST__(x, mean, standard_deviation, cumulative)</code> {: #normdist data-toc-label="NORMDIST" }
 </summary>
 Returns the value of the normal distribution function (or normal cumulative distribution
@@ -3919,70 +3919,70 @@ function) for a specified value, mean, and standard deviation.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__NORMINV__(x, mean, standard_deviation)</code> {: #norminv data-toc-label="NORMINV" }
 </summary>
 Returns the value of the inverse normal distribution function for a specified value, mean, and standard deviation.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__NORMSDIST__(x)</code> {: #normsdist data-toc-label="NORMSDIST" }
 </summary>
 Returns the value of the standard normal cumulative distribution function for a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__NORMSINV__(x)</code> {: #normsinv data-toc-label="NORMSINV" }
 </summary>
 Returns the value of the inverse standard normal distribution function for a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__PEARSON__(data_y, data_x)</code> {: #pearson data-toc-label="PEARSON" }
 </summary>
 Calculates r, the Pearson product-moment correlation coefficient of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__PERCENTILE__(data, percentile)</code> {: #percentile data-toc-label="PERCENTILE" }
 </summary>
 Returns the value at a given percentile of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__PERCENTRANK__(data, value, significant_digits=None)</code> {: #percentrank data-toc-label="PERCENTRANK" }
 </summary>
 Returns the percentage rank (percentile) of a specified value in a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__PERCENTRANK_EXC__(data, value, significant_digits=None)</code> {: #percentrank_exc data-toc-label="PERCENTRANK_EXC" }
 </summary>
 Returns the percentage rank (percentile) from 0 to 1 exclusive of a specified value in a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__PERCENTRANK_INC__(data, value, significant_digits=None)</code> {: #percentrank_inc data-toc-label="PERCENTRANK_INC" }
 </summary>
 Returns the percentage rank (percentile) from 0 to 1 inclusive of a specified value in a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__PERMUT__(n, k)</code> {: #permut data-toc-label="PERMUT" }
 </summary>
 Returns the number of ways to choose some number of objects from a pool of a given size of objects, considering order.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__POISSON__(x, mean, cumulative)</code> {: #poisson data-toc-label="POISSON" }
 </summary>
 Returns the value of the Poisson distribution function (or Poisson cumulative distribution
@@ -3990,63 +3990,63 @@ function) for a specified value and mean.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__PROB__(data, probabilities, low_limit, high_limit=None)</code> {: #prob data-toc-label="PROB" }
 </summary>
 Given a set of values and corresponding probabilities, calculates the probability that a value chosen at random falls between two limits.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__QUARTILE__(data, quartile_number)</code> {: #quartile data-toc-label="QUARTILE" }
 </summary>
 Returns a value nearest to a specified quartile of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__RANK_AVG__(value, data, is_ascending=None)</code> {: #rank_avg data-toc-label="RANK_AVG" }
 </summary>
 Returns the rank of a specified value in a dataset. If there is more than one entry of the same value in the dataset, the average rank of the entries will be returned.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__RANK_EQ__(value, data, is_ascending=None)</code> {: #rank_eq data-toc-label="RANK_EQ" }
 </summary>
 Returns the rank of a specified value in a dataset. If there is more than one entry of the same value in the dataset, the top rank of the entries will be returned.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__RSQ__(data_y, data_x)</code> {: #rsq data-toc-label="RSQ" }
 </summary>
 Calculates the square of r, the Pearson product-moment correlation coefficient of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__SKEW__(value1, value2)</code> {: #skew data-toc-label="SKEW" }
 </summary>
 Calculates the skewness of a dataset, which describes the symmetry of that dataset about the mean.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__SLOPE__(data_y, data_x)</code> {: #slope data-toc-label="SLOPE" }
 </summary>
 Calculates the slope of the line resulting from linear regression of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__SMALL__(data, n)</code> {: #small data-toc-label="SMALL" }
 </summary>
 Returns the nth smallest element from a data set, where n is user-defined.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__STANDARDIZE__(value, mean, standard_deviation)</code> {: #standardize data-toc-label="STANDARDIZE" }
 </summary>
 Calculates the normalized equivalent of a random variable given mean and standard deviation of the distribution.
@@ -4185,84 +4185,84 @@ Calculates the standard deviation based on an entire population, setting text to
 ```
 
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__STEYX__(data_y, data_x)</code> {: #steyx data-toc-label="STEYX" }
 </summary>
 Calculates the standard error of the predicted y-value for each x in the regression of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__TDIST__(x, degrees_freedom, tails)</code> {: #tdist data-toc-label="TDIST" }
 </summary>
 Calculates the probability for Student's t-distribution with a given input (x).
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__TINV__(probability, degrees_freedom)</code> {: #tinv data-toc-label="TINV" }
 </summary>
 Calculates the inverse of the two-tailed TDIST function.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__TRIMMEAN__(data, exclude_proportion)</code> {: #trimmean data-toc-label="TRIMMEAN" }
 </summary>
 Calculates the mean of a dataset excluding some proportion of data from the high and low ends of the dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__TTEST__(range1, range2, tails, type)</code> {: #ttest data-toc-label="TTEST" }
 </summary>
 Returns the probability associated with t-test. Determines whether two samples are likely to have come from the same two underlying populations that have the same mean.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__T_INV__(probability, degrees_freedom)</code> {: #t_inv data-toc-label="T_INV" }
 </summary>
 Calculates the negative inverse of the one-tailed TDIST function.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__T_INV_2T__(probability, degrees_freedom)</code> {: #t_inv_2t data-toc-label="T_INV_2T" }
 </summary>
 Calculates the inverse of the two-tailed TDIST function.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__VAR__(value1, value2)</code> {: #var data-toc-label="VAR" }
 </summary>
 Calculates the variance based on a sample.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__VARA__(value1, value2)</code> {: #vara data-toc-label="VARA" }
 </summary>
 Calculates an estimate of variance based on a sample, setting text to the value `0`.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__VARP__(value1, value2)</code> {: #varp data-toc-label="VARP" }
 </summary>
 Calculates the variance based on an entire population.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__VARPA__(value1, value2)</code> {: #varpa data-toc-label="VARPA" }
 </summary>
 Calculates the variance based on an entire population, setting text to the value `0`.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__WEIBULL__(x, shape, scale, cumulative)</code> {: #weibull data-toc-label="WEIBULL" }
 </summary>
 Returns the value of the Weibull distribution function (or Weibull cumulative distribution
@@ -4270,7 +4270,7 @@ function) for a specified shape and scale.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__ZTEST__(data, value, standard_deviation)</code> {: #ztest data-toc-label="ZTEST" }
 </summary>
 Returns the two-tailed P-value of a Z-test with standard distribution.
@@ -5138,7 +5138,7 @@ False
 ```
 
 </details>
-<details>
+<details markdown><summary class="unimplemented">
 #### <code>__TEXT__(number, format_type)</code> {: #text data-toc-label="TEXT" }
 </summary>
 Converts a number into text according to a specified format. It is not yet implemented in

--- a/help/en/docs/functions.md
+++ b/help/en/docs/functions.md
@@ -1,3 +1,11 @@
+<style>
+    /* Makes headers for functions in-line with the "expand" arrow */
+    .wm-page-content summary h4 {
+      display: inline-block;
+      font-size: 14px;
+    }
+</style>
+
 # Function Reference {: data-toc-label='' }
 
 Grist formulas support most Excel functions, as well as the Python programming language.
@@ -36,9 +44,7 @@ Python (see [Python documentation](https://docs.python.org/3.11/)). Here are som
 <!-- BEGIN mkpydocs docs -->
 ### Grist
 <details id="record" markdown><summary >
-#### Record
-<code>class __Record__</code>
-<a class="headerlink" href="#record" title="Permanent link">#</a>
+#### <code>class __Record__</code> {: #record }
 </summary>
 A Record represents a record of data. It is the primary means of accessing values in formulas. A
 Record for a particular table has a property for each data and formula column in the table.
@@ -56,16 +62,12 @@ def Name_Length(rec, table):
 ```
 </details>
 <details id="_field" markdown><summary >
-#### $Field
-<code>__$__*Field* or __rec__*.Field*</code>
-<a class="headerlink" href="#_field" title="Permanent link">#</a>
+#### <code>__$__*Field* or __rec__*.Field*</code> {: #_field }
 </summary>
 Access the field named "Field" of the current record. E.g. `$First_Name` or `rec.First_Name`.
 </details>
 <details id="_group" markdown><summary >
-#### $group
-<code>__$group__</code>
-<a class="headerlink" href="#_group" title="Permanent link">#</a>
+#### <code>__$group__</code> {: #_group }
 </summary>
 In a [summary table](summary-tables.md), `$group` is a special field
 containing the list of Records that are summarized by the current summary line.  E.g. the
@@ -82,9 +84,7 @@ sum(r.Shares * r.Price for r in $group)   # Sum of shares * price products
 ```
 </details>
 <details id="recordset" markdown><summary >
-#### RecordSet
-<code>class __RecordSet__</code>
-<a class="headerlink" href="#recordset" title="Permanent link">#</a>
+#### <code>class __RecordSet__</code> {: #recordset }
 </summary>
 A RecordSet represents a collection of records, as returned by `Table.lookupRecords()` or
 `$group` property in summary views.
@@ -105,9 +105,7 @@ min(Tasks.lookupRecords(Owner="Bob").DueDate)
 You can get the number of records in a RecordSet using `len`, e.g. `len($group)`.
 </details>
 <details id="find_" markdown><summary >
-#### find.*
-<code>RecordSet.**find.\***(value)</code>
-<a class="headerlink" href="#find_" title="Permanent link">#</a>
+#### <code>RecordSet.**find.\***(value)</code> {: #find_ }
 </summary>
 A set of methods for finding values in sorted sets of records, as returned by
 [`lookupRecords`](#lookuprecords). For example:
@@ -153,9 +151,7 @@ return rate.Hourly_Rate
 Note that this is also much faster when there are many rates for the same Person and Role.
 </details>
 <details id="usertable" markdown><summary >
-#### UserTable
-<code>class __UserTable__</code>
-<a class="headerlink" href="#usertable" title="Permanent link">#</a>
+#### <code>class __UserTable__</code> {: #usertable }
 </summary>
 Each data table in the document is represented in the code by an instance of `UserTable` class.
 These names are always capitalized. A UserTable provides access to all the records in the table,
@@ -164,9 +160,7 @@ as well as methods to look up particular records.
 Every table in the document is available to all formulas.
 </details>
 <details id="all" markdown><summary >
-#### all
-<code>UserTable.__all__</code>
-<a class="headerlink" href="#all" title="Permanent link">#</a>
+#### <code>UserTable.__all__</code> {: #all }
 </summary>
 The list of all the records in this table.
 
@@ -181,9 +175,7 @@ sum(r.Population for r in Countries.all)
 ```
 </details>
 <details id="lookupone" markdown><summary >
-#### lookupOne
-<code>UserTable.__lookupOne__(Field_In_Lookup_Table=value, ...)</code>
-<a class="headerlink" href="#lookupone" title="Permanent link">#</a>
+#### <code>UserTable.__lookupOne__(Field_In_Lookup_Table=value, ...)</code> {: #lookupone }
 </summary>
 Returns a [Record](#record) matching the given field=value arguments. The value may be any
 expression,
@@ -212,9 +204,7 @@ Rates.lookupOne(Person=$id, order_by="-Date")      # Rate with the latest Date.
 ```
 </details>
 <details id="lookuprecords" markdown><summary >
-#### lookupRecords
-<code>UserTable.__lookupRecords__(Field_In_Lookup_Table=value, ...)</code>
-<a class="headerlink" href="#lookuprecords" title="Permanent link">#</a>
+#### <code>UserTable.__lookupRecords__(Field_In_Lookup_Table=value, ...)</code> {: #lookuprecords }
 </summary>
 Returns a [RecordSet](#recordset) matching the given field=value arguments. The value may be
 any expression,
@@ -258,17 +248,13 @@ Learn more about [lookupRecords](references-lookups.md#lookuprecords).
 </details>
 ### Cumulative
 <details id="next" markdown><summary >
-#### NEXT
-<code>__NEXT__(rec, *, group_by=(), order_by)</code>
-<a class="headerlink" href="#next" title="Permanent link">#</a>
+#### <code>__NEXT__(rec, *, group_by=(), order_by)</code> {: #next }
 </summary>
 Finds the next record in the table according to the order specified by `order_by`, and
 grouping specified by `group_by`. See [`PREVIOUS`](#previous) for details.
 </details>
 <details id="previous" markdown><summary >
-#### PREVIOUS
-<code>__PREVIOUS__(rec, *, group_by=(), order_by)</code>
-<a class="headerlink" href="#previous" title="Permanent link">#</a>
+#### <code>__PREVIOUS__(rec, *, group_by=(), order_by)</code> {: #previous }
 </summary>
 Finds the previous record in the table according to the order specified by `order_by`, and
 grouping specified by `group_by`. Each of these arguments may be a column ID or a tuple of
@@ -304,9 +290,7 @@ PREVIOUS(rec, group_by=("Account", "Year"), order_by=("Date", "-Amount"))
 ```
 </details>
 <details id="rank" markdown><summary >
-#### RANK
-<code>__RANK__(rec, *, group_by=(), order_by, order='asc')</code>
-<a class="headerlink" href="#rank" title="Permanent link">#</a>
+#### <code>__RANK__(rec, *, group_by=(), order_by, order='asc')</code> {: #rank }
 </summary>
 Returns the rank (or position) of this record in the table according to the order specified by
 `order_by`, and grouping specified by `group_by`. See [`PREVIOUS`](#previous) for details of
@@ -327,9 +311,7 @@ decreasing score.
 </details>
 ### Date
 <details id="date" markdown><summary >
-#### DATE
-<code>__DATE__(year, month, day)</code>
-<a class="headerlink" href="#date" title="Permanent link">#</a>
+#### <code>__DATE__(year, month, day)</code> {: #date }
 </summary>
 Returns the `datetime.datetime` object that represents a particular date.
 The DATE function is most useful in formulas where year, month, and day are formulas, not
@@ -376,9 +358,7 @@ datetime.date(2007, 12, 16)
 ```
 </details>
 <details id="dateadd" markdown><summary >
-#### DATEADD
-<code>__DATEADD__(start_date, days=0, months=0, years=0, weeks=0)</code>
-<a class="headerlink" href="#dateadd" title="Permanent link">#</a>
+#### <code>__DATEADD__(start_date, days=0, months=0, years=0, weeks=0)</code> {: #dateadd }
 </summary>
 Returns the date a given number of days, months, years, or weeks away from `start_date`. You may
 specify arguments in any order if you specify argument names. Use negative values to subtract.
@@ -409,9 +389,7 @@ datetime.date(2025, 3, 26)
 
 </details>
 <details id="datedif" markdown><summary >
-#### DATEDIF
-<code>__DATEDIF__(start_date, end_date, unit)</code>
-<a class="headerlink" href="#datedif" title="Permanent link">#</a>
+#### <code>__DATEDIF__(start_date, end_date, unit)</code> {: #datedif }
 </summary>
 Calculates the number of days, months, or years between two dates.
 Unit indicates the type of information that you want returned:
@@ -455,9 +433,7 @@ The difference between 1 and 15, ignoring the months and the years of the dates 
 ```
 </details>
 <details id="datevalue" markdown><summary >
-#### DATEVALUE
-<code>__DATEVALUE__(date_string, tz=None)</code>
-<a class="headerlink" href="#datevalue" title="Permanent link">#</a>
+#### <code>__DATEVALUE__(date_string, tz=None)</code> {: #datevalue }
 </summary>
 Converts a date that is stored as text to a `datetime` object.
 
@@ -490,9 +466,7 @@ datetime.datetime(2003, 1, 2, 0, 0, tzinfo=moment.tzinfo('America/New_York'))
 ```
 </details>
 <details id="date_to_xl" markdown><summary >
-#### DATE_TO_XL
-<code>__DATE_TO_XL__(date_value)</code>
-<a class="headerlink" href="#date_to_xl" title="Permanent link">#</a>
+#### <code>__DATE_TO_XL__(date_value)</code> {: #date_to_xl }
 </summary>
 Converts a Python `date` or `datetime` object to the serial number as used by
 Excel, with December 30, 1899 as serial number 1.
@@ -516,9 +490,7 @@ See XL_TO_DATE for more explanation.
 ```
 </details>
 <details id="day" markdown><summary >
-#### DAY
-<code>__DAY__(date)</code>
-<a class="headerlink" href="#day" title="Permanent link">#</a>
+#### <code>__DAY__(date)</code> {: #day }
 </summary>
 Returns the day of a date, as an integer ranging from 1 to 31. Same as `date.day`.
 
@@ -540,9 +512,7 @@ Returns the day of a date, as an integer ranging from 1 to 31. Same as `date.day
 
 </details>
 <details id="days" markdown><summary >
-#### DAYS
-<code>__DAYS__(end_date, start_date)</code>
-<a class="headerlink" href="#days" title="Permanent link">#</a>
+#### <code>__DAYS__(end_date, start_date)</code> {: #days }
 </summary>
 Returns the number of days between two dates. Same as `(end_date - start_date).days`.
 
@@ -564,9 +534,7 @@ Returns the number of days between two dates. Same as `(end_date - start_date).d
 
 </details>
 <details id="dtime" markdown><summary >
-#### DTIME
-<code>__DTIME__(value, tz=None)</code>
-<a class="headerlink" href="#dtime" title="Permanent link">#</a>
+#### <code>__DTIME__(value, tz=None)</code> {: #dtime }
 </summary>
 Returns the value converted to a python `datetime` object. The value may be a
 `string`, `date` (interpreted as midnight on that day), `time` (interpreted as a
@@ -609,9 +577,7 @@ datetime.datetime(2008, 1, 1, 0, 0, tzinfo=moment.tzinfo('America/New_York'))
 
 </details>
 <details id="edate" markdown><summary >
-#### EDATE
-<code>__EDATE__(start_date, months)</code>
-<a class="headerlink" href="#edate" title="Permanent link">#</a>
+#### <code>__EDATE__(start_date, months)</code> {: #edate }
 </summary>
 Returns the date that is the given number of months before or after `start_date`. Use
 EDATE to calculate maturity dates or due dates that fall on the same day of the month as the
@@ -645,9 +611,7 @@ datetime.date(2012, 3, 1)
 
 </details>
 <details id="eomonth" markdown><summary >
-#### EOMONTH
-<code>__EOMONTH__(start_date, months)</code>
-<a class="headerlink" href="#eomonth" title="Permanent link">#</a>
+#### <code>__EOMONTH__(start_date, months)</code> {: #eomonth }
 </summary>
 Returns the date for the last day of the month that is the indicated number of months before or
 after start_date. Use EOMONTH to calculate maturity dates or due dates that fall on the last day
@@ -676,9 +640,7 @@ datetime.date(2012, 3, 31)
 
 </details>
 <details id="hour" markdown><summary >
-#### HOUR
-<code>__HOUR__(time)</code>
-<a class="headerlink" href="#hour" title="Permanent link">#</a>
+#### <code>__HOUR__(time)</code> {: #hour }
 </summary>
 Same as `time.hour`.
 
@@ -700,9 +662,7 @@ Same as `time.hour`.
 
 </details>
 <details id="isoweeknum" markdown><summary >
-#### ISOWEEKNUM
-<code>__ISOWEEKNUM__(date)</code>
-<a class="headerlink" href="#isoweeknum" title="Permanent link">#</a>
+#### <code>__ISOWEEKNUM__(date)</code> {: #isoweeknum }
 </summary>
 Returns the ISO week number of the year for a given date.
 
@@ -719,9 +679,7 @@ Returns the ISO week number of the year for a given date.
 
 </details>
 <details id="minute" markdown><summary >
-#### MINUTE
-<code>__MINUTE__(time)</code>
-<a class="headerlink" href="#minute" title="Permanent link">#</a>
+#### <code>__MINUTE__(time)</code> {: #minute }
 </summary>
 Returns the minutes of `datetime`, as an integer from 0 to 59.
 Same as `time.minute`.
@@ -749,9 +707,7 @@ Same as `time.minute`.
 
 </details>
 <details id="month" markdown><summary >
-#### MONTH
-<code>__MONTH__(date)</code>
-<a class="headerlink" href="#month" title="Permanent link">#</a>
+#### <code>__MONTH__(date)</code> {: #month }
 </summary>
 Returns the month of a date represented, as an integer from from 1 (January) to 12 (December).
 Same as `date.month`.
@@ -774,9 +730,7 @@ Same as `date.month`.
 
 </details>
 <details id="moonphase" markdown><summary >
-#### MOONPHASE
-<code>__MOONPHASE__(date, output='emoji')</code>
-<a class="headerlink" href="#moonphase" title="Permanent link">#</a>
+#### <code>__MOONPHASE__(date, output='emoji')</code> {: #moonphase }
 </summary>
 Returns the phase of the moon on the given date. The output defaults to a moon-phase emoji.
 
@@ -825,16 +779,12 @@ True
 
 </details>
 <details id="now" markdown><summary >
-#### NOW
-<code>__NOW__(tz=None)</code>
-<a class="headerlink" href="#now" title="Permanent link">#</a>
+#### <code>__NOW__(tz=None)</code> {: #now }
 </summary>
 Returns the `datetime` object for the current time.
 </details>
 <details id="second" markdown><summary >
-#### SECOND
-<code>__SECOND__(time)</code>
-<a class="headerlink" href="#second" title="Permanent link">#</a>
+#### <code>__SECOND__(time)</code> {: #second }
 </summary>
 Returns the seconds of `datetime`, as an integer from 0 to 59.
 Same as `time.second`.
@@ -857,16 +807,12 @@ Same as `time.second`.
 
 </details>
 <details id="today" markdown><summary >
-#### TODAY
-<code>__TODAY__(tz=None)</code>
-<a class="headerlink" href="#today" title="Permanent link">#</a>
+#### <code>__TODAY__(tz=None)</code> {: #today }
 </summary>
 Returns the `date` object for the current date.
 </details>
 <details id="weekday" markdown><summary >
-#### WEEKDAY
-<code>__WEEKDAY__(date, return_type=1)</code>
-<a class="headerlink" href="#weekday" title="Permanent link">#</a>
+#### <code>__WEEKDAY__(date, return_type=1)</code> {: #weekday }
 </summary>
 Returns the day of the week corresponding to a date. The day is given as an integer, ranging
 from 1 (Sunday) to 7 (Saturday), by default.
@@ -911,9 +857,7 @@ Return_type determines the type of the returned value.
 ```
 </details>
 <details id="weeknum" markdown><summary >
-#### WEEKNUM
-<code>__WEEKNUM__(date, return_type=1)</code>
-<a class="headerlink" href="#weeknum" title="Permanent link">#</a>
+#### <code>__WEEKNUM__(date, return_type=1)</code> {: #weeknum }
 </summary>
 Returns the week number of a specific date. For example, the week containing January 1 is the
 first week of the year, and is numbered week 1.
@@ -954,9 +898,7 @@ Return_type determines which week is considered the first week of the year.
 ```
 </details>
 <details id="xl_to_date" markdown><summary >
-#### XL_TO_DATE
-<code>__XL_TO_DATE__(value, tz=None)</code>
-<a class="headerlink" href="#xl_to_date" title="Permanent link">#</a>
+#### <code>__XL_TO_DATE__(value, tz=None)</code> {: #xl_to_date }
 </summary>
 Converts a provided Excel serial number representing a date into a `datetime` object.
 Value is interpreted as the number of days since December 30, 1899.
@@ -985,9 +927,7 @@ datetime.datetime(2012, 3, 14, 1, 30, tzinfo=moment.tzinfo('America/New_York'))
 ```
 </details>
 <details id="year" markdown><summary >
-#### YEAR
-<code>__YEAR__(date)</code>
-<a class="headerlink" href="#year" title="Permanent link">#</a>
+#### <code>__YEAR__(date)</code> {: #year }
 </summary>
 Returns the year corresponding to a date as an integer.
 Same as `date.year`.
@@ -1010,9 +950,7 @@ Same as `date.year`.
 
 </details>
 <details id="yearfrac" markdown><summary >
-#### YEARFRAC
-<code>__YEARFRAC__(start_date, end_date, basis=0)</code>
-<a class="headerlink" href="#yearfrac" title="Permanent link">#</a>
+#### <code>__YEARFRAC__(start_date, end_date, basis=0)</code> {: #yearfrac }
 </summary>
 Calculates the fraction of the year represented by the number of whole days between two dates.
 
@@ -1061,18 +999,14 @@ Fraction between same dates, using the Actual/365 basis argument. Uses a 365 day
 </details>
 ### Info
 <details id="cell" markdown><summary class="unimplemented">
-#### CELL
-<code>__CELL__(info_type, reference)</code>
-<a class="headerlink" href="#cell" title="Permanent link">#</a>
+#### <code>__CELL__(info_type, reference)</code> {: #cell }
 </summary>
 Returns the requested information about the specified cell. This is not implemented in Grist
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="isblank" markdown><summary class="unimplemented">
-#### ISBLANK
-<code>__ISBLANK__(value)</code>
-<a class="headerlink" href="#isblank" title="Permanent link">#</a>
+#### <code>__ISBLANK__(value)</code> {: #isblank }
 </summary>
 Returns whether a value refers to an empty cell. It isn't implemented in Grist. To check for an
 empty string, use `value == ""`.
@@ -1080,9 +1014,7 @@ empty string, use `value == ""`.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="isemail" markdown><summary >
-#### ISEMAIL
-<code>__ISEMAIL__(value)</code>
-<a class="headerlink" href="#isemail" title="Permanent link">#</a>
+#### <code>__ISEMAIL__(value)</code> {: #isemail }
 </summary>
 Returns whether a value is a valid email address.
 
@@ -1112,9 +1044,7 @@ False
 ```
 </details>
 <details id="iserr" markdown><summary >
-#### ISERR
-<code>__ISERR__(value)</code>
-<a class="headerlink" href="#iserr" title="Permanent link">#</a>
+#### <code>__ISERR__(value)</code> {: #iserr }
 </summary>
 Checks whether a value is an error. In other words, it returns true
 if using `value` directly would raise an exception.
@@ -1138,9 +1068,7 @@ False
 ```
 </details>
 <details id="iserror" markdown><summary >
-#### ISERROR
-<code>__ISERROR__(value)</code>
-<a class="headerlink" href="#iserror" title="Permanent link">#</a>
+#### <code>__ISERROR__(value)</code> {: #iserror }
 </summary>
 Checks whether a value is an error or an invalid value. It is similar to `ISERR`, but also
 returns true for an invalid value such as NaN or a text value in a Numeric column.
@@ -1164,9 +1092,7 @@ True
 ```
 </details>
 <details id="islogical" markdown><summary >
-#### ISLOGICAL
-<code>__ISLOGICAL__(value)</code>
-<a class="headerlink" href="#islogical" title="Permanent link">#</a>
+#### <code>__ISLOGICAL__(value)</code> {: #islogical }
 </summary>
 Checks whether a value is `True` or `False`.
 
@@ -1198,9 +1124,7 @@ False
 
 </details>
 <details id="isna" markdown><summary >
-#### ISNA
-<code>__ISNA__(value)</code>
-<a class="headerlink" href="#isna" title="Permanent link">#</a>
+#### <code>__ISNA__(value)</code> {: #isna }
 </summary>
 Checks whether a value is the error `#N/A`.
 
@@ -1227,9 +1151,7 @@ False
 
 </details>
 <details id="isnontext" markdown><summary >
-#### ISNONTEXT
-<code>__ISNONTEXT__(value)</code>
-<a class="headerlink" href="#isnontext" title="Permanent link">#</a>
+#### <code>__ISNONTEXT__(value)</code> {: #isnontext }
 </summary>
 Checks whether a value is non-textual.
 
@@ -1266,9 +1188,7 @@ True
 
 </details>
 <details id="isnumber" markdown><summary >
-#### ISNUMBER
-<code>__ISNUMBER__(value)</code>
-<a class="headerlink" href="#isnumber" title="Permanent link">#</a>
+#### <code>__ISNUMBER__(value)</code> {: #isnumber }
 </summary>
 Checks whether a value is a number.
 
@@ -1314,9 +1234,7 @@ False
 ```
 </details>
 <details id="isref" markdown><summary >
-#### ISREF
-<code>__ISREF__(value)</code>
-<a class="headerlink" href="#isref" title="Permanent link">#</a>
+#### <code>__ISREF__(value)</code> {: #isref }
 </summary>
 Checks whether a value is a table record.
 
@@ -1338,9 +1256,7 @@ False
 
 </details>
 <details id="isreflist" markdown><summary >
-#### ISREFLIST
-<code>__ISREFLIST__(value)</code>
-<a class="headerlink" href="#isreflist" title="Permanent link">#</a>
+#### <code>__ISREFLIST__(value)</code> {: #isreflist }
 </summary>
 Checks whether a value is a [`RecordSet`](#recordset),
 the type of values in Reference List columns.
@@ -1363,9 +1279,7 @@ False
 
 </details>
 <details id="istext" markdown><summary >
-#### ISTEXT
-<code>__ISTEXT__(value)</code>
-<a class="headerlink" href="#istext" title="Permanent link">#</a>
+#### <code>__ISTEXT__(value)</code> {: #istext }
 </summary>
 Checks whether a value is text.
 
@@ -1402,9 +1316,7 @@ False
 
 </details>
 <details id="isurl" markdown><summary >
-#### ISURL
-<code>__ISURL__(value)</code>
-<a class="headerlink" href="#isurl" title="Permanent link">#</a>
+#### <code>__ISURL__(value)</code> {: #isurl }
 </summary>
 Checks whether a value is a valid URL. It does not need to be fully qualified, or to include
 "http://" and "www". It does not follow a standard, but attempts to work similarly to ISURL in
@@ -1434,9 +1346,7 @@ False
 ```
 </details>
 <details id="n" markdown><summary >
-#### N
-<code>__N__(value)</code>
-<a class="headerlink" href="#n" title="Permanent link">#</a>
+#### <code>__N__(value)</code> {: #n }
 </summary>
 Returns the value converted to a number. True/False are converted to 1/0. A date is converted to
 Excel-style serial number of the date. Anything else is converted to 0.
@@ -1474,9 +1384,7 @@ Excel-style serial number of the date. Anything else is converted to 0.
 
 </details>
 <details id="na" markdown><summary >
-#### NA
-<code>__NA__()</code>
-<a class="headerlink" href="#na" title="Permanent link">#</a>
+#### <code>__NA__()</code> {: #na }
 </summary>
 Returns the "value not available" error, `#N/A`.
 
@@ -1488,9 +1396,7 @@ True
 
 </details>
 <details id="peek" markdown><summary >
-#### PEEK
-<code>__PEEK__(func)</code>
-<a class="headerlink" href="#peek" title="Permanent link">#</a>
+#### <code>__PEEK__(func)</code> {: #peek }
 </summary>
 Evaluates the given expression without creating dependencies
 or requiring that referenced values are up to date, using whatever value it finds in a cell.
@@ -1503,9 +1409,7 @@ already stored in `$B` without requiring that `$B` is first calculated to the la
 Therefore `A` will be calculated first, and `B` can use `$A` without problems.
 </details>
 <details id="record_2" markdown><summary >
-#### RECORD
-<code>__RECORD__(record_or_list, dates_as_iso=False, expand_refs=0)</code>
-<a class="headerlink" href="#record_2" title="Permanent link">#</a>
+#### <code>__RECORD__(record_or_list, dates_as_iso=False, expand_refs=0)</code> {: #record }
 </summary>
 Returns a Python dictionary with all fields in the given record. If a list of records is given,
 returns a list of corresponding Python dictionaries.
@@ -1532,17 +1436,13 @@ RECORD(People.lookupRecords(Department="HR"))
 ```
 </details>
 <details id="request" markdown><summary class="unimplemented">
-#### REQUEST
-<code>__REQUEST__(url, params=None, headers=None, method='GET', data=None, json=None)</code>
-<a class="headerlink" href="#request" title="Permanent link">#</a>
+#### <code>__REQUEST__(url, params=None, headers=None, method='GET', data=None, json=None)</code> {: #request }
 </summary>
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="type" markdown><summary class="unimplemented">
-#### TYPE
-<code>__TYPE__(value)</code>
-<a class="headerlink" href="#type" title="Permanent link">#</a>
+#### <code>__TYPE__(value)</code> {: #type }
 </summary>
 Returns a number associated with the type of data passed into the function. This is not
 implemented in Grist. Use `isinstance(value, type)` or `type(value)`.
@@ -1551,9 +1451,7 @@ implemented in Grist. Use `isinstance(value, type)` or `type(value)`.
 </details>
 ### Logical
 <details id="and" markdown><summary >
-#### AND
-<code>__AND__(logical_expression, *logical_expressions)</code>
-<a class="headerlink" href="#and" title="Permanent link">#</a>
+#### <code>__AND__(logical_expression, *logical_expressions)</code> {: #and }
 </summary>
 Returns True if all of the arguments are logically true, and False if any are false.
 Same as `all([value1, value2, ...])`.
@@ -1586,9 +1484,7 @@ False
 
 </details>
 <details id="false" markdown><summary >
-#### FALSE
-<code>__FALSE__()</code>
-<a class="headerlink" href="#false" title="Permanent link">#</a>
+#### <code>__FALSE__()</code> {: #false }
 </summary>
 Returns the logical value `False`. You may also use the value `False` directly. This
 function is provided primarily for compatibility with other spreadsheet programs.
@@ -1601,9 +1497,7 @@ False
 
 </details>
 <details id="if" markdown><summary >
-#### IF
-<code>__IF__(logical_expression, value_if_true, value_if_false)</code>
-<a class="headerlink" href="#if" title="Permanent link">#</a>
+#### <code>__IF__(logical_expression, value_if_true, value_if_false)</code> {: #if }
 </summary>
 Returns one value if a logical expression is `True` and another if it is `False`.
 
@@ -1646,9 +1540,7 @@ to evaluate to `1` rather than raise an exception.
 ```
 </details>
 <details id="iferror" markdown><summary >
-#### IFERROR
-<code>__IFERROR__(value, value_if_error='')</code>
-<a class="headerlink" href="#iferror" title="Permanent link">#</a>
+#### <code>__IFERROR__(value, value_if_error='')</code> {: #iferror }
 </summary>
 Returns the first argument if it is not an error value, otherwise returns the second argument if
 present, or a blank if the second argument is absent.
@@ -1677,9 +1569,7 @@ NOTE: Grist handles values that raise an exception by wrapping them to use lazy 
 ```
 </details>
 <details id="not" markdown><summary >
-#### NOT
-<code>__NOT__(logical_expression)</code>
-<a class="headerlink" href="#not" title="Permanent link">#</a>
+#### <code>__NOT__(logical_expression)</code> {: #not }
 </summary>
 `True`. Same as `not logical_expression`.
 
@@ -1696,9 +1586,7 @@ True
 
 </details>
 <details id="or" markdown><summary >
-#### OR
-<code>__OR__(logical_expression, *logical_expressions)</code>
-<a class="headerlink" href="#or" title="Permanent link">#</a>
+#### <code>__OR__(logical_expression, *logical_expressions)</code> {: #or }
 </summary>
 Returns True if any of the arguments is logically true, and false if all of the
 arguments are false.
@@ -1742,9 +1630,7 @@ True
 
 </details>
 <details id="true" markdown><summary >
-#### TRUE
-<code>__TRUE__()</code>
-<a class="headerlink" href="#true" title="Permanent link">#</a>
+#### <code>__TRUE__()</code> {: #true }
 </summary>
 Returns the logical value `True`. You may also use the value `True` directly. This
 function is provided primarily for compatibility with other spreadsheet programs.
@@ -1758,9 +1644,7 @@ True
 </details>
 ### Lookup
 <details id="lookupone_2" markdown><summary >
-#### lookupOne
-<code>UserTable.__lookupOne__(Field_In_Lookup_Table=value, ...)</code>
-<a class="headerlink" href="#lookupone_2" title="Permanent link">#</a>
+#### <code>UserTable.__lookupOne__(Field_In_Lookup_Table=value, ...)</code> {: #lookupone }
 </summary>
 Returns a [Record](#record) matching the given field=value arguments. The value may be any
 expression,
@@ -1789,9 +1673,7 @@ Rates.lookupOne(Person=$id, order_by="-Date")      # Rate with the latest Date.
 ```
 </details>
 <details id="lookuprecords_2" markdown><summary >
-#### lookupRecords
-<code>UserTable.__lookupRecords__(Field_In_Lookup_Table=value, ...)</code>
-<a class="headerlink" href="#lookuprecords_2" title="Permanent link">#</a>
+#### <code>UserTable.__lookupRecords__(Field_In_Lookup_Table=value, ...)</code> {: #lookuprecords }
 </summary>
 Returns a [RecordSet](#recordset) matching the given field=value arguments. The value may be
 any expression,
@@ -1834,45 +1716,35 @@ value.
 Learn more about [lookupRecords](references-lookups.md#lookuprecords).
 </details>
 <details id="address" markdown><summary class="unimplemented">
-#### ADDRESS
-<code>__ADDRESS__(row, column, absolute_relative_mode, use_a1_notation, sheet)</code>
-<a class="headerlink" href="#address" title="Permanent link">#</a>
+#### <code>__ADDRESS__(row, column, absolute_relative_mode, use_a1_notation, sheet)</code> {: #address }
 </summary>
 Returns a cell reference as a string.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="choose" markdown><summary class="unimplemented">
-#### CHOOSE
-<code>__CHOOSE__(index, choice1, choice2)</code>
-<a class="headerlink" href="#choose" title="Permanent link">#</a>
+#### <code>__CHOOSE__(index, choice1, choice2)</code> {: #choose }
 </summary>
 Returns an element from a list of choices based on index.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="column" markdown><summary class="unimplemented">
-#### COLUMN
-<code>__COLUMN__(cell_reference=None)</code>
-<a class="headerlink" href="#column" title="Permanent link">#</a>
+#### <code>__COLUMN__(cell_reference=None)</code> {: #column }
 </summary>
 Returns the column number of a specified cell, with `A=1`.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="columns" markdown><summary class="unimplemented">
-#### COLUMNS
-<code>__COLUMNS__(range)</code>
-<a class="headerlink" href="#columns" title="Permanent link">#</a>
+#### <code>__COLUMNS__(range)</code> {: #columns }
 </summary>
 Returns the number of columns in a specified array or range.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="contains" markdown><summary >
-#### CONTAINS
-<code>__CONTAINS__(value, match_empty=no_match_empty)</code>
-<a class="headerlink" href="#contains" title="Permanent link">#</a>
+#### <code>__CONTAINS__(value, match_empty=no_match_empty)</code> {: #contains }
 </summary>
 Use this marker with [UserTable.lookupRecords](#lookuprecords) to find records
 where a field of a list type (such as `Choice List` or `Reference List`) contains the given value.
@@ -1902,99 +1774,77 @@ If `g` is `''` (i.e. equal to `match_empty`) then the column `genre` in the retu
 will either be an empty list (or other container) or a list containing `g` as usual.
 </details>
 <details id="getpivotdata" markdown><summary class="unimplemented">
-#### GETPIVOTDATA
-<code>__GETPIVOTDATA__(value_name, any_pivot_table_cell, original_column_1, pivot_item_1=None, *args)</code>
-<a class="headerlink" href="#getpivotdata" title="Permanent link">#</a>
+#### <code>__GETPIVOTDATA__(value_name, any_pivot_table_cell, original_column_1, pivot_item_1=None, *args)</code> {: #getpivotdata }
 </summary>
 Extracts an aggregated value from a pivot table that corresponds to the specified row and column headings.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="hlookup" markdown><summary class="unimplemented">
-#### HLOOKUP
-<code>__HLOOKUP__(search_key, range, index, is_sorted)</code>
-<a class="headerlink" href="#hlookup" title="Permanent link">#</a>
+#### <code>__HLOOKUP__(search_key, range, index, is_sorted)</code> {: #hlookup }
 </summary>
 Horizontal lookup. Searches across the first row of a range for a key and returns the value of a specified cell in the column found.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="hyperlink" markdown><summary class="unimplemented">
-#### HYPERLINK
-<code>__HYPERLINK__(url, link_label)</code>
-<a class="headerlink" href="#hyperlink" title="Permanent link">#</a>
+#### <code>__HYPERLINK__(url, link_label)</code> {: #hyperlink }
 </summary>
 Creates a hyperlink inside a cell.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="index" markdown><summary class="unimplemented">
-#### INDEX
-<code>__INDEX__(reference, row, column)</code>
-<a class="headerlink" href="#index" title="Permanent link">#</a>
+#### <code>__INDEX__(reference, row, column)</code> {: #index }
 </summary>
 Returns the content of a cell, specified by row and column offset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="indirect" markdown><summary class="unimplemented">
-#### INDIRECT
-<code>__INDIRECT__(cell_reference_as_string)</code>
-<a class="headerlink" href="#indirect" title="Permanent link">#</a>
+#### <code>__INDIRECT__(cell_reference_as_string)</code> {: #indirect }
 </summary>
 Returns a cell reference specified by a string.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="lookup" markdown><summary class="unimplemented">
-#### LOOKUP
-<code>__LOOKUP__(search_key, search_range_or_search_result_array, result_range=None)</code>
-<a class="headerlink" href="#lookup" title="Permanent link">#</a>
+#### <code>__LOOKUP__(search_key, search_range_or_search_result_array, result_range=None)</code> {: #lookup }
 </summary>
 Looks through a row or column for a key and returns the value of the cell in a result range located in the same position as the search row or column.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="match" markdown><summary class="unimplemented">
-#### MATCH
-<code>__MATCH__(search_key, range, search_type)</code>
-<a class="headerlink" href="#match" title="Permanent link">#</a>
+#### <code>__MATCH__(search_key, range, search_type)</code> {: #match }
 </summary>
 Returns the relative position of an item in a range that matches a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="offset" markdown><summary class="unimplemented">
-#### OFFSET
-<code>__OFFSET__(cell_reference, offset_rows, offset_columns, height, width)</code>
-<a class="headerlink" href="#offset" title="Permanent link">#</a>
+#### <code>__OFFSET__(cell_reference, offset_rows, offset_columns, height, width)</code> {: #offset }
 </summary>
 Returns a range reference shifted a specified number of rows and columns from a starting cell reference.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="row" markdown><summary class="unimplemented">
-#### ROW
-<code>__ROW__(cell_reference)</code>
-<a class="headerlink" href="#row" title="Permanent link">#</a>
+#### <code>__ROW__(cell_reference)</code> {: #row }
 </summary>
 Returns the row number of a specified cell.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="rows" markdown><summary class="unimplemented">
-#### ROWS
-<code>__ROWS__(range)</code>
-<a class="headerlink" href="#rows" title="Permanent link">#</a>
+#### <code>__ROWS__(range)</code> {: #rows }
 </summary>
 Returns the number of rows in a specified array or range.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="self_hyperlink" markdown><summary >
-#### SELF_HYPERLINK
-<code>__SELF_HYPERLINK__(label=None, page=None, **kwargs)</code>
-<a class="headerlink" href="#self_hyperlink" title="Permanent link">#</a>
+#### <code>__SELF_HYPERLINK__(label=None, page=None, **kwargs)</code> {: #self_hyperlink }
 </summary>
 Creates a link to the current document.  All parameters are optional.
 
@@ -2045,9 +1895,7 @@ TypeError: unexpected keyword argument 'Linky_Link' (not of form LinkKey_NAME)
 
 </details>
 <details id="vlookup" markdown><summary >
-#### VLOOKUP
-<code>__VLOOKUP__(table, **field_value_pairs)</code>
-<a class="headerlink" href="#vlookup" title="Permanent link">#</a>
+#### <code>__VLOOKUP__(table, **field_value_pairs)</code> {: #vlookup }
 </summary>
 Vertical lookup. Searches the given table for a record matching the given `field=value`
 arguments. If multiple records match, returns one of them. If none match, returns the special
@@ -2070,9 +1918,7 @@ VLOOKUP(People, First_Name="Lewis", Last_Name="Carroll").Age
 </details>
 ### Math
 <details id="abs" markdown><summary >
-#### ABS
-<code>__ABS__(value)</code>
-<a class="headerlink" href="#abs" title="Permanent link">#</a>
+#### <code>__ABS__(value)</code> {: #abs }
 </summary>
 Returns the absolute value of a number.
 
@@ -2094,9 +1940,7 @@ Returns the absolute value of a number.
 
 </details>
 <details id="acos" markdown><summary >
-#### ACOS
-<code>__ACOS__(value)</code>
-<a class="headerlink" href="#acos" title="Permanent link">#</a>
+#### <code>__ACOS__(value)</code> {: #acos }
 </summary>
 Returns the inverse cosine of a value, in radians.
 
@@ -2113,9 +1957,7 @@ Returns the inverse cosine of a value, in radians.
 
 </details>
 <details id="acosh" markdown><summary >
-#### ACOSH
-<code>__ACOSH__(value)</code>
-<a class="headerlink" href="#acosh" title="Permanent link">#</a>
+#### <code>__ACOSH__(value)</code> {: #acosh }
 </summary>
 Returns the inverse hyperbolic cosine of a number.
 
@@ -2132,9 +1974,7 @@ Returns the inverse hyperbolic cosine of a number.
 
 </details>
 <details id="arabic" markdown><summary >
-#### ARABIC
-<code>__ARABIC__(roman_numeral)</code>
-<a class="headerlink" href="#arabic" title="Permanent link">#</a>
+#### <code>__ARABIC__(roman_numeral)</code> {: #arabic }
 </summary>
 Computes the value of a Roman numeral.
 
@@ -2151,9 +1991,7 @@ Computes the value of a Roman numeral.
 
 </details>
 <details id="asin" markdown><summary >
-#### ASIN
-<code>__ASIN__(value)</code>
-<a class="headerlink" href="#asin" title="Permanent link">#</a>
+#### <code>__ASIN__(value)</code> {: #asin }
 </summary>
 Returns the inverse sine of a value, in radians.
 
@@ -2175,9 +2013,7 @@ Returns the inverse sine of a value, in radians.
 
 </details>
 <details id="asinh" markdown><summary >
-#### ASINH
-<code>__ASINH__(value)</code>
-<a class="headerlink" href="#asinh" title="Permanent link">#</a>
+#### <code>__ASINH__(value)</code> {: #asinh }
 </summary>
 Returns the inverse hyperbolic sine of a number.
 
@@ -2194,9 +2030,7 @@ Returns the inverse hyperbolic sine of a number.
 
 </details>
 <details id="atan" markdown><summary >
-#### ATAN
-<code>__ATAN__(value)</code>
-<a class="headerlink" href="#atan" title="Permanent link">#</a>
+#### <code>__ATAN__(value)</code> {: #atan }
 </summary>
 Returns the inverse tangent of a value, in radians.
 
@@ -2218,9 +2052,7 @@ Returns the inverse tangent of a value, in radians.
 
 </details>
 <details id="atan2" markdown><summary >
-#### ATAN2
-<code>__ATAN2__(x, y)</code>
-<a class="headerlink" href="#atan2" title="Permanent link">#</a>
+#### <code>__ATAN2__(x, y)</code> {: #atan2 }
 </summary>
 Returns the angle between the x-axis and a line segment from the origin (0,0) to specified
 coordinate pair (`x`,`y`), in radians.
@@ -2253,9 +2085,7 @@ coordinate pair (`x`,`y`), in radians.
 
 </details>
 <details id="atanh" markdown><summary >
-#### ATANH
-<code>__ATANH__(value)</code>
-<a class="headerlink" href="#atanh" title="Permanent link">#</a>
+#### <code>__ATANH__(value)</code> {: #atanh }
 </summary>
 Returns the inverse hyperbolic tangent of a number.
 
@@ -2272,9 +2102,7 @@ Returns the inverse hyperbolic tangent of a number.
 
 </details>
 <details id="ceiling" markdown><summary >
-#### CEILING
-<code>__CEILING__(value, factor=1)</code>
-<a class="headerlink" href="#ceiling" title="Permanent link">#</a>
+#### <code>__CEILING__(value, factor=1)</code> {: #ceiling }
 </summary>
 Rounds a number up to the nearest multiple of factor, or the nearest integer if the factor is
 omitted or 1.
@@ -2307,9 +2135,7 @@ omitted or 1.
 
 </details>
 <details id="combin" markdown><summary >
-#### COMBIN
-<code>__COMBIN__(n, k)</code>
-<a class="headerlink" href="#combin" title="Permanent link">#</a>
+#### <code>__COMBIN__(n, k)</code> {: #combin }
 </summary>
 Returns the number of ways to choose some number of objects from a pool of a given size of
 objects.
@@ -2332,9 +2158,7 @@ objects.
 
 </details>
 <details id="cos" markdown><summary >
-#### COS
-<code>__COS__(angle)</code>
-<a class="headerlink" href="#cos" title="Permanent link">#</a>
+#### <code>__COS__(angle)</code> {: #cos }
 </summary>
 Returns the cosine of an angle provided in radians.
 
@@ -2356,9 +2180,7 @@ Returns the cosine of an angle provided in radians.
 
 </details>
 <details id="cosh" markdown><summary >
-#### COSH
-<code>__COSH__(value)</code>
-<a class="headerlink" href="#cosh" title="Permanent link">#</a>
+#### <code>__COSH__(value)</code> {: #cosh }
 </summary>
 Returns the hyperbolic cosine of any real number.
 
@@ -2375,9 +2197,7 @@ Returns the hyperbolic cosine of any real number.
 
 </details>
 <details id="degrees" markdown><summary >
-#### DEGREES
-<code>__DEGREES__(angle)</code>
-<a class="headerlink" href="#degrees" title="Permanent link">#</a>
+#### <code>__DEGREES__(angle)</code> {: #degrees }
 </summary>
 Converts an angle value in radians to degrees.
 
@@ -2394,9 +2214,7 @@ Converts an angle value in radians to degrees.
 
 </details>
 <details id="even" markdown><summary >
-#### EVEN
-<code>__EVEN__(value)</code>
-<a class="headerlink" href="#even" title="Permanent link">#</a>
+#### <code>__EVEN__(value)</code> {: #even }
 </summary>
 Rounds a number up to the nearest even integer, rounding away from zero.
 
@@ -2423,9 +2241,7 @@ Rounds a number up to the nearest even integer, rounding away from zero.
 
 </details>
 <details id="exp" markdown><summary >
-#### EXP
-<code>__EXP__(exponent)</code>
-<a class="headerlink" href="#exp" title="Permanent link">#</a>
+#### <code>__EXP__(exponent)</code> {: #exp }
 </summary>
 Returns Euler's number, e (~2.718) raised to a power.
 
@@ -2442,9 +2258,7 @@ Returns Euler's number, e (~2.718) raised to a power.
 
 </details>
 <details id="fact" markdown><summary >
-#### FACT
-<code>__FACT__(value)</code>
-<a class="headerlink" href="#fact" title="Permanent link">#</a>
+#### <code>__FACT__(value)</code> {: #fact }
 </summary>
 Returns the factorial of a number.
 
@@ -2478,9 +2292,7 @@ ValueError: factorial() not defined for negative values
 
 </details>
 <details id="factdouble" markdown><summary >
-#### FACTDOUBLE
-<code>__FACTDOUBLE__(value)</code>
-<a class="headerlink" href="#factdouble" title="Permanent link">#</a>
+#### <code>__FACTDOUBLE__(value)</code> {: #factdouble }
 </summary>
 Returns the "double factorial" of a number.
 
@@ -2507,9 +2319,7 @@ Returns the "double factorial" of a number.
 
 </details>
 <details id="floor" markdown><summary >
-#### FLOOR
-<code>__FLOOR__(value, factor=1)</code>
-<a class="headerlink" href="#floor" title="Permanent link">#</a>
+#### <code>__FLOOR__(value, factor=1)</code> {: #floor }
 </summary>
 Rounds a number down to the nearest integer multiple of specified significance.
 
@@ -2543,9 +2353,7 @@ ValueError: factor argument invalid
 
 </details>
 <details id="gcd" markdown><summary >
-#### GCD
-<code>__GCD__(value1, *more_values)</code>
-<a class="headerlink" href="#gcd" title="Permanent link">#</a>
+#### <code>__GCD__(value1, *more_values)</code> {: #gcd }
 </summary>
 Returns the greatest common divisor of one or more integers.
 
@@ -2587,9 +2395,7 @@ Returns the greatest common divisor of one or more integers.
 
 </details>
 <details id="int" markdown><summary >
-#### INT
-<code>__INT__(value)</code>
-<a class="headerlink" href="#int" title="Permanent link">#</a>
+#### <code>__INT__(value)</code> {: #int }
 </summary>
 Rounds a number down to the nearest integer that is less than or equal to it.
 
@@ -2611,9 +2417,7 @@ Rounds a number down to the nearest integer that is less than or equal to it.
 
 </details>
 <details id="lcm" markdown><summary >
-#### LCM
-<code>__LCM__(value1, *more_values)</code>
-<a class="headerlink" href="#lcm" title="Permanent link">#</a>
+#### <code>__LCM__(value1, *more_values)</code> {: #lcm }
 </summary>
 Returns the least common multiple of one or more integers.
 
@@ -2655,9 +2459,7 @@ Returns the least common multiple of one or more integers.
 
 </details>
 <details id="ln" markdown><summary >
-#### LN
-<code>__LN__(value)</code>
-<a class="headerlink" href="#ln" title="Permanent link">#</a>
+#### <code>__LN__(value)</code> {: #ln }
 </summary>
 Returns the the logarithm of a number, base e (Euler's number).
 
@@ -2679,9 +2481,7 @@ Returns the the logarithm of a number, base e (Euler's number).
 
 </details>
 <details id="log" markdown><summary >
-#### LOG
-<code>__LOG__(value, base=10)</code>
-<a class="headerlink" href="#log" title="Permanent link">#</a>
+#### <code>__LOG__(value, base=10)</code> {: #log }
 </summary>
 Returns the the logarithm of a number given a base.
 
@@ -2703,9 +2503,7 @@ Returns the the logarithm of a number given a base.
 
 </details>
 <details id="log10" markdown><summary >
-#### LOG10
-<code>__LOG10__(value)</code>
-<a class="headerlink" href="#log10" title="Permanent link">#</a>
+#### <code>__LOG10__(value)</code> {: #log10 }
 </summary>
 Returns the the logarithm of a number, base 10.
 
@@ -2732,9 +2530,7 @@ Returns the the logarithm of a number, base 10.
 
 </details>
 <details id="mod" markdown><summary >
-#### MOD
-<code>__MOD__(dividend, divisor)</code>
-<a class="headerlink" href="#mod" title="Permanent link">#</a>
+#### <code>__MOD__(dividend, divisor)</code> {: #mod }
 </summary>
 Returns the result of the modulo operator, the remainder after a division operation.
 
@@ -2761,9 +2557,7 @@ Returns the result of the modulo operator, the remainder after a division operat
 
 </details>
 <details id="mround" markdown><summary >
-#### MROUND
-<code>__MROUND__(value, factor)</code>
-<a class="headerlink" href="#mround" title="Permanent link">#</a>
+#### <code>__MROUND__(value, factor)</code> {: #mround }
 </summary>
 Rounds one number to the nearest integer multiple of another.
 
@@ -2792,9 +2586,7 @@ ValueError: factor argument invalid
 
 </details>
 <details id="multinomial" markdown><summary >
-#### MULTINOMIAL
-<code>__MULTINOMIAL__(value1, *more_values)</code>
-<a class="headerlink" href="#multinomial" title="Permanent link">#</a>
+#### <code>__MULTINOMIAL__(value1, *more_values)</code> {: #multinomial }
 </summary>
 Returns the factorial of the sum of values divided by the product of the values' factorials.
 
@@ -2821,9 +2613,7 @@ Returns the factorial of the sum of values divided by the product of the values'
 
 </details>
 <details id="num" markdown><summary >
-#### NUM
-<code>__NUM__(value)</code>
-<a class="headerlink" href="#num" title="Permanent link">#</a>
+#### <code>__NUM__(value)</code> {: #num }
 </summary>
 For a Python floating-point value that's actually an integer, returns a Python integer type.
 Otherwise, returns the value unchanged. This is helpful sometimes when a value comes from a
@@ -2852,9 +2642,7 @@ Numeric Grist column (represented as floats), but when int values are actually e
 
 </details>
 <details id="odd" markdown><summary >
-#### ODD
-<code>__ODD__(value)</code>
-<a class="headerlink" href="#odd" title="Permanent link">#</a>
+#### <code>__ODD__(value)</code> {: #odd }
 </summary>
 Rounds a number up to the nearest odd integer.
 
@@ -2886,9 +2674,7 @@ Rounds a number up to the nearest odd integer.
 
 </details>
 <details id="pi" markdown><summary >
-#### PI
-<code>__PI__()</code>
-<a class="headerlink" href="#pi" title="Permanent link">#</a>
+#### <code>__PI__()</code> {: #pi }
 </summary>
 Returns the value of Pi to 14 decimal places.
 
@@ -2910,9 +2696,7 @@ Returns the value of Pi to 14 decimal places.
 
 </details>
 <details id="power" markdown><summary >
-#### POWER
-<code>__POWER__(base, exponent)</code>
-<a class="headerlink" href="#power" title="Permanent link">#</a>
+#### <code>__POWER__(base, exponent)</code> {: #power }
 </summary>
 Returns a number raised to a power.
 
@@ -2934,9 +2718,7 @@ Returns a number raised to a power.
 
 </details>
 <details id="product" markdown><summary >
-#### PRODUCT
-<code>__PRODUCT__(factor1, *more_factors)</code>
-<a class="headerlink" href="#product" title="Permanent link">#</a>
+#### <code>__PRODUCT__(factor1, *more_factors)</code> {: #product }
 </summary>
 Returns the result of multiplying a series of numbers together. Each argument may be a number or
 an array.
@@ -2958,9 +2740,7 @@ an array.
 ```
 </details>
 <details id="quotient" markdown><summary >
-#### QUOTIENT
-<code>__QUOTIENT__(dividend, divisor)</code>
-<a class="headerlink" href="#quotient" title="Permanent link">#</a>
+#### <code>__QUOTIENT__(dividend, divisor)</code> {: #quotient }
 </summary>
 Returns one number divided by another, without the remainder.
 
@@ -2982,9 +2762,7 @@ Returns one number divided by another, without the remainder.
 
 </details>
 <details id="radians" markdown><summary >
-#### RADIANS
-<code>__RADIANS__(angle)</code>
-<a class="headerlink" href="#radians" title="Permanent link">#</a>
+#### <code>__RADIANS__(angle)</code> {: #radians }
 </summary>
 Converts an angle value in degrees to radians.
 
@@ -2996,23 +2774,17 @@ Converts an angle value in degrees to radians.
 
 </details>
 <details id="rand" markdown><summary >
-#### RAND
-<code>__RAND__()</code>
-<a class="headerlink" href="#rand" title="Permanent link">#</a>
+#### <code>__RAND__()</code> {: #rand }
 </summary>
 Returns a random number between 0 inclusive and 1 exclusive.
 </details>
 <details id="randbetween" markdown><summary >
-#### RANDBETWEEN
-<code>__RANDBETWEEN__(low, high)</code>
-<a class="headerlink" href="#randbetween" title="Permanent link">#</a>
+#### <code>__RANDBETWEEN__(low, high)</code> {: #randbetween }
 </summary>
 Returns a uniformly random integer between two values, inclusive.
 </details>
 <details id="roman" markdown><summary >
-#### ROMAN
-<code>__ROMAN__(number, form_unused=None)</code>
-<a class="headerlink" href="#roman" title="Permanent link">#</a>
+#### <code>__ROMAN__(number, form_unused=None)</code> {: #roman }
 </summary>
 Formats a number in Roman numerals. The second argument is ignored in this implementation.
 
@@ -3039,9 +2811,7 @@ Formats a number in Roman numerals. The second argument is ignored in this imple
 
 </details>
 <details id="round" markdown><summary >
-#### ROUND
-<code>__ROUND__(value, places=0)</code>
-<a class="headerlink" href="#round" title="Permanent link">#</a>
+#### <code>__ROUND__(value, places=0)</code> {: #round }
 </summary>
 Rounds a number to a certain number of decimal places,
 by default to the nearest whole number if the number of places is not given.
@@ -3107,9 +2877,7 @@ in the case of a tie, i.e. when the last digit is 5.
 
 </details>
 <details id="rounddown" markdown><summary >
-#### ROUNDDOWN
-<code>__ROUNDDOWN__(value, places=0)</code>
-<a class="headerlink" href="#rounddown" title="Permanent link">#</a>
+#### <code>__ROUNDDOWN__(value, places=0)</code> {: #rounddown }
 </summary>
 Rounds a number to a certain number of decimal places, always rounding down towards zero.
 
@@ -3141,9 +2909,7 @@ Rounds a number to a certain number of decimal places, always rounding down towa
 
 </details>
 <details id="roundup" markdown><summary >
-#### ROUNDUP
-<code>__ROUNDUP__(value, places=0)</code>
-<a class="headerlink" href="#roundup" title="Permanent link">#</a>
+#### <code>__ROUNDUP__(value, places=0)</code> {: #roundup }
 </summary>
 Rounds a number to a certain number of decimal places, always rounding up away from zero.
 
@@ -3175,9 +2941,7 @@ Rounds a number to a certain number of decimal places, always rounding up away f
 
 </details>
 <details id="seriessum" markdown><summary >
-#### SERIESSUM
-<code>__SERIESSUM__(x, n, m, a)</code>
-<a class="headerlink" href="#seriessum" title="Permanent link">#</a>
+#### <code>__SERIESSUM__(x, n, m, a)</code> {: #seriessum }
 </summary>
 Given parameters x, n, m, and a, returns the power series sum a_1*x^n + a_2*x^(n+m)
 + ... + a_i*x^(n+(i-1)m), where i is the number of entries in range `a`.
@@ -3205,9 +2969,7 @@ Given parameters x, n, m, and a, returns the power series sum a_1*x^n + a_2*x^(n
 
 </details>
 <details id="sign" markdown><summary >
-#### SIGN
-<code>__SIGN__(value)</code>
-<a class="headerlink" href="#sign" title="Permanent link">#</a>
+#### <code>__SIGN__(value)</code> {: #sign }
 </summary>
 Given an input number, returns `-1` if it is negative, `1` if positive, and `0` if it is zero.
 
@@ -3229,9 +2991,7 @@ Given an input number, returns `-1` if it is negative, `1` if positive, and `0` 
 
 </details>
 <details id="sin" markdown><summary >
-#### SIN
-<code>__SIN__(angle)</code>
-<a class="headerlink" href="#sin" title="Permanent link">#</a>
+#### <code>__SIN__(angle)</code> {: #sin }
 </summary>
 Returns the sine of an angle provided in radians.
 
@@ -3258,9 +3018,7 @@ Returns the sine of an angle provided in radians.
 
 </details>
 <details id="sinh" markdown><summary >
-#### SINH
-<code>__SINH__(value)</code>
-<a class="headerlink" href="#sinh" title="Permanent link">#</a>
+#### <code>__SINH__(value)</code> {: #sinh }
 </summary>
 Returns the hyperbolic sine of any real number.
 
@@ -3272,9 +3030,7 @@ Returns the hyperbolic sine of any real number.
 
 </details>
 <details id="sqrt" markdown><summary >
-#### SQRT
-<code>__SQRT__(value)</code>
-<a class="headerlink" href="#sqrt" title="Permanent link">#</a>
+#### <code>__SQRT__(value)</code> {: #sqrt }
 </summary>
 Returns the positive square root of a positive number.
 
@@ -3298,9 +3054,7 @@ ValueError: math domain error
 
 </details>
 <details id="sqrtpi" markdown><summary >
-#### SQRTPI
-<code>__SQRTPI__(value)</code>
-<a class="headerlink" href="#sqrtpi" title="Permanent link">#</a>
+#### <code>__SQRTPI__(value)</code> {: #sqrtpi }
 </summary>
 Returns the positive square root of the product of Pi and the given positive number.
 
@@ -3317,18 +3071,14 @@ Returns the positive square root of the product of Pi and the given positive num
 
 </details>
 <details id="subtotal" markdown><summary class="unimplemented">
-#### SUBTOTAL
-<code>__SUBTOTAL__(function_code, range1, range2)</code>
-<a class="headerlink" href="#subtotal" title="Permanent link">#</a>
+#### <code>__SUBTOTAL__(function_code, range1, range2)</code> {: #subtotal }
 </summary>
 Returns a subtotal for a vertical range of cells using a specified aggregation function.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="sum" markdown><summary >
-#### SUM
-<code>__SUM__(value1, *more_values)</code>
-<a class="headerlink" href="#sum" title="Permanent link">#</a>
+#### <code>__SUM__(value1, *more_values)</code> {: #sum }
 </summary>
 Returns the sum of a series of numbers. Each argument may be a number or an array.
 Non-numeric values are ignored.
@@ -3350,27 +3100,21 @@ Non-numeric values are ignored.
 ```
 </details>
 <details id="sumif" markdown><summary class="unimplemented">
-#### SUMIF
-<code>__SUMIF__(records, criterion, sum_range)</code>
-<a class="headerlink" href="#sumif" title="Permanent link">#</a>
+#### <code>__SUMIF__(records, criterion, sum_range)</code> {: #sumif }
 </summary>
 Returns a conditional sum across a range.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="sumifs" markdown><summary class="unimplemented">
-#### SUMIFS
-<code>__SUMIFS__(sum_range, criteria_range1, criterion1, *args)</code>
-<a class="headerlink" href="#sumifs" title="Permanent link">#</a>
+#### <code>__SUMIFS__(sum_range, criteria_range1, criterion1, *args)</code> {: #sumifs }
 </summary>
 Returns the sum of a range depending on multiple criteria.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="sumproduct" markdown><summary >
-#### SUMPRODUCT
-<code>__SUMPRODUCT__(array1, *more_arrays)</code>
-<a class="headerlink" href="#sumproduct" title="Permanent link">#</a>
+#### <code>__SUMPRODUCT__(array1, *more_arrays)</code> {: #sumproduct }
 </summary>
 Multiplies corresponding components in two equally-sized arrays,
 and returns the sum of those products.
@@ -3398,18 +3142,14 @@ and returns the sum of those products.
 
 </details>
 <details id="sumsq" markdown><summary class="unimplemented">
-#### SUMSQ
-<code>__SUMSQ__(value1, value2)</code>
-<a class="headerlink" href="#sumsq" title="Permanent link">#</a>
+#### <code>__SUMSQ__(value1, value2)</code> {: #sumsq }
 </summary>
 Returns the sum of the squares of a series of numbers and/or cells.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="tan" markdown><summary >
-#### TAN
-<code>__TAN__(angle)</code>
-<a class="headerlink" href="#tan" title="Permanent link">#</a>
+#### <code>__TAN__(angle)</code> {: #tan }
 </summary>
 Returns the tangent of an angle provided in radians.
 
@@ -3431,9 +3171,7 @@ Returns the tangent of an angle provided in radians.
 
 </details>
 <details id="tanh" markdown><summary >
-#### TANH
-<code>__TANH__(value)</code>
-<a class="headerlink" href="#tanh" title="Permanent link">#</a>
+#### <code>__TANH__(value)</code> {: #tanh }
 </summary>
 Returns the hyperbolic tangent of any real number.
 
@@ -3455,9 +3193,7 @@ Returns the hyperbolic tangent of any real number.
 
 </details>
 <details id="trunc" markdown><summary >
-#### TRUNC
-<code>__TRUNC__(value, places=0)</code>
-<a class="headerlink" href="#trunc" title="Permanent link">#</a>
+#### <code>__TRUNC__(value, places=0)</code> {: #trunc }
 </summary>
 Truncates a number to a certain number of significant digits by omitting less significant
 digits.
@@ -3480,9 +3216,7 @@ digits.
 
 </details>
 <details id="uuid" markdown><summary >
-#### UUID
-<code>__UUID__()</code>
-<a class="headerlink" href="#uuid" title="Permanent link">#</a>
+#### <code>__UUID__()</code> {: #uuid }
 </summary>
 Generate a random UUID-formatted string identifier.
 
@@ -3494,9 +3228,7 @@ UUID() each time.
 </details>
 ### Schedule
 <details id="schedule" markdown><summary >
-#### SCHEDULE
-<code>__SCHEDULE__(schedule, start=None, count=10, end=None)</code>
-<a class="headerlink" href="#schedule" title="Permanent link">#</a>
+#### <code>__SCHEDULE__(schedule, start=None, count=10, end=None)</code> {: #schedule }
 </summary>
 Returns the list of `datetime` objects generated according to the `schedule` string. Starts at
 `start`, which defaults to NOW(). Generates at most `count` results (10 by default). If `end` is
@@ -3619,18 +3351,14 @@ The time zone of `start` determines the time zone of the generated times.
 </details>
 ### Stats
 <details id="avedev" markdown><summary class="unimplemented">
-#### AVEDEV
-<code>__AVEDEV__(value1, value2)</code>
-<a class="headerlink" href="#avedev" title="Permanent link">#</a>
+#### <code>__AVEDEV__(value1, value2)</code> {: #avedev }
 </summary>
 Calculates the average of the magnitudes of deviations of data from a dataset's mean.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="average" markdown><summary >
-#### AVERAGE
-<code>__AVERAGE__(value, *more_values)</code>
-<a class="headerlink" href="#average" title="Permanent link">#</a>
+#### <code>__AVERAGE__(value, *more_values)</code> {: #average }
 </summary>
 Returns the numerical average value in a dataset, ignoring non-numerical values.
 
@@ -3662,9 +3390,7 @@ ZeroDivisionError: float division by zero
 
 </details>
 <details id="averagea" markdown><summary >
-#### AVERAGEA
-<code>__AVERAGEA__(value, *more_values)</code>
-<a class="headerlink" href="#averagea" title="Permanent link">#</a>
+#### <code>__AVERAGEA__(value, *more_values)</code> {: #averagea }
 </summary>
 Returns the numerical average value in a dataset, counting non-numerical values as 0.
 
@@ -3695,27 +3421,21 @@ False as 0.
 
 </details>
 <details id="averageif" markdown><summary class="unimplemented">
-#### AVERAGEIF
-<code>__AVERAGEIF__(criteria_range, criterion, average_range=None)</code>
-<a class="headerlink" href="#averageif" title="Permanent link">#</a>
+#### <code>__AVERAGEIF__(criteria_range, criterion, average_range=None)</code> {: #averageif }
 </summary>
 Returns the average of a range depending on criteria.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="averageifs" markdown><summary class="unimplemented">
-#### AVERAGEIFS
-<code>__AVERAGEIFS__(average_range, criteria_range1, criterion1, *args)</code>
-<a class="headerlink" href="#averageifs" title="Permanent link">#</a>
+#### <code>__AVERAGEIFS__(average_range, criteria_range1, criterion1, *args)</code> {: #averageifs }
 </summary>
 Returns the average of a range depending on multiple criteria.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="average_weighted" markdown><summary >
-#### AVERAGE_WEIGHTED
-<code>__AVERAGE_WEIGHTED__(pairs)</code>
-<a class="headerlink" href="#average_weighted" title="Permanent link">#</a>
+#### <code>__AVERAGE_WEIGHTED__(pairs)</code> {: #average_weighted }
 </summary>
 Given a list of (value, weight) pairs, finds the average of the values weighted by the
 corresponding weights. Ignores any pairs with a non-numerical value or weight.
@@ -3741,9 +3461,7 @@ list of pairs.
 
 </details>
 <details id="binomdist" markdown><summary class="unimplemented">
-#### BINOMDIST
-<code>__BINOMDIST__(num_successes, num_trials, prob_success, cumulative)</code>
-<a class="headerlink" href="#binomdist" title="Permanent link">#</a>
+#### <code>__BINOMDIST__(num_successes, num_trials, prob_success, cumulative)</code> {: #binomdist }
 </summary>
 Calculates the probability of drawing a certain number of successes (or a maximum number of
 successes) in a certain number of tries given a population of a certain size containing a
@@ -3752,27 +3470,21 @@ certain number of successes, with replacement of draws.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="confidence" markdown><summary class="unimplemented">
-#### CONFIDENCE
-<code>__CONFIDENCE__(alpha, standard_deviation, pop_size)</code>
-<a class="headerlink" href="#confidence" title="Permanent link">#</a>
+#### <code>__CONFIDENCE__(alpha, standard_deviation, pop_size)</code> {: #confidence }
 </summary>
 Calculates the width of half the confidence interval for a normal distribution.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="correl" markdown><summary class="unimplemented">
-#### CORREL
-<code>__CORREL__(data_y, data_x)</code>
-<a class="headerlink" href="#correl" title="Permanent link">#</a>
+#### <code>__CORREL__(data_y, data_x)</code> {: #correl }
 </summary>
 Calculates r, the Pearson product-moment correlation coefficient of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="count" markdown><summary >
-#### COUNT
-<code>__COUNT__(value, *more_values)</code>
-<a class="headerlink" href="#count" title="Permanent link">#</a>
+#### <code>__COUNT__(value, *more_values)</code> {: #count }
 </summary>
 Returns the count of numerical and date/datetime values in a dataset,
 ignoring other types of values.
@@ -3808,9 +3520,7 @@ and blank values, and text representations of numbers, are ignored.
 
 </details>
 <details id="counta" markdown><summary >
-#### COUNTA
-<code>__COUNTA__(value, *more_values)</code>
-<a class="headerlink" href="#counta" title="Permanent link">#</a>
+#### <code>__COUNTA__(value, *more_values)</code> {: #counta }
 </summary>
 Returns the count of all values in a dataset, including non-numerical values.
 
@@ -3839,45 +3549,35 @@ Each argument may be a value or an array.
 
 </details>
 <details id="covar" markdown><summary class="unimplemented">
-#### COVAR
-<code>__COVAR__(data_y, data_x)</code>
-<a class="headerlink" href="#covar" title="Permanent link">#</a>
+#### <code>__COVAR__(data_y, data_x)</code> {: #covar }
 </summary>
 Calculates the covariance of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="critbinom" markdown><summary class="unimplemented">
-#### CRITBINOM
-<code>__CRITBINOM__(num_trials, prob_success, target_prob)</code>
-<a class="headerlink" href="#critbinom" title="Permanent link">#</a>
+#### <code>__CRITBINOM__(num_trials, prob_success, target_prob)</code> {: #critbinom }
 </summary>
 Calculates the smallest value for which the cumulative binomial distribution is greater than or equal to a specified criteria.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="devsq" markdown><summary class="unimplemented">
-#### DEVSQ
-<code>__DEVSQ__(value1, value2)</code>
-<a class="headerlink" href="#devsq" title="Permanent link">#</a>
+#### <code>__DEVSQ__(value1, value2)</code> {: #devsq }
 </summary>
 Calculates the sum of squares of deviations based on a sample.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="expondist" markdown><summary class="unimplemented">
-#### EXPONDIST
-<code>__EXPONDIST__(x, lambda_, cumulative)</code>
-<a class="headerlink" href="#expondist" title="Permanent link">#</a>
+#### <code>__EXPONDIST__(x, lambda_, cumulative)</code> {: #expondist }
 </summary>
 Returns the value of the exponential distribution function with a specified lambda at a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="fdist" markdown><summary class="unimplemented">
-#### FDIST
-<code>__FDIST__(x, degrees_freedom1, degrees_freedom2)</code>
-<a class="headerlink" href="#fdist" title="Permanent link">#</a>
+#### <code>__FDIST__(x, degrees_freedom1, degrees_freedom2)</code> {: #fdist }
 </summary>
 Calculates the right-tailed F probability distribution (degree of diversity) for two data sets
 with given input x. Alternately called Fisher-Snedecor distribution or Snedecor's F
@@ -3886,36 +3586,28 @@ distribution.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="fisher" markdown><summary class="unimplemented">
-#### FISHER
-<code>__FISHER__(value)</code>
-<a class="headerlink" href="#fisher" title="Permanent link">#</a>
+#### <code>__FISHER__(value)</code> {: #fisher }
 </summary>
 Returns the Fisher transformation of a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="fisherinv" markdown><summary class="unimplemented">
-#### FISHERINV
-<code>__FISHERINV__(value)</code>
-<a class="headerlink" href="#fisherinv" title="Permanent link">#</a>
+#### <code>__FISHERINV__(value)</code> {: #fisherinv }
 </summary>
 Returns the inverse Fisher transformation of a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="forecast" markdown><summary class="unimplemented">
-#### FORECAST
-<code>__FORECAST__(x, data_y, data_x)</code>
-<a class="headerlink" href="#forecast" title="Permanent link">#</a>
+#### <code>__FORECAST__(x, data_y, data_x)</code> {: #forecast }
 </summary>
 Calculates the expected y-value for a specified x based on a linear regression of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="f_dist" markdown><summary class="unimplemented">
-#### F_DIST
-<code>__F_DIST__(x, degrees_freedom1, degrees_freedom2, cumulative)</code>
-<a class="headerlink" href="#f_dist" title="Permanent link">#</a>
+#### <code>__F_DIST__(x, degrees_freedom1, degrees_freedom2, cumulative)</code> {: #f_dist }
 </summary>
 Calculates the left-tailed F probability distribution (degree of diversity) for two data sets
 with given input x. Alternately called Fisher-Snedecor distribution or Snedecor's F
@@ -3924,9 +3616,7 @@ distribution.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="f_dist_rt" markdown><summary class="unimplemented">
-#### F_DIST_RT
-<code>__F_DIST_RT__(x, degrees_freedom1, degrees_freedom2)</code>
-<a class="headerlink" href="#f_dist_rt" title="Permanent link">#</a>
+#### <code>__F_DIST_RT__(x, degrees_freedom1, degrees_freedom2)</code> {: #f_dist_rt }
 </summary>
 Calculates the right-tailed F probability distribution (degree of diversity) for two data sets
 with given input x. Alternately called Fisher-Snedecor distribution or Snedecor's F
@@ -3935,81 +3625,63 @@ distribution.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="geomean" markdown><summary class="unimplemented">
-#### GEOMEAN
-<code>__GEOMEAN__(value1, value2)</code>
-<a class="headerlink" href="#geomean" title="Permanent link">#</a>
+#### <code>__GEOMEAN__(value1, value2)</code> {: #geomean }
 </summary>
 Calculates the geometric mean of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="harmean" markdown><summary class="unimplemented">
-#### HARMEAN
-<code>__HARMEAN__(value1, value2)</code>
-<a class="headerlink" href="#harmean" title="Permanent link">#</a>
+#### <code>__HARMEAN__(value1, value2)</code> {: #harmean }
 </summary>
 Calculates the harmonic mean of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="hypgeomdist" markdown><summary class="unimplemented">
-#### HYPGEOMDIST
-<code>__HYPGEOMDIST__(num_successes, num_draws, successes_in_pop, pop_size)</code>
-<a class="headerlink" href="#hypgeomdist" title="Permanent link">#</a>
+#### <code>__HYPGEOMDIST__(num_successes, num_draws, successes_in_pop, pop_size)</code> {: #hypgeomdist }
 </summary>
 Calculates the probability of drawing a certain number of successes in a certain number of tries given a population of a certain size containing a certain number of successes, without replacement of draws.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="intercept" markdown><summary class="unimplemented">
-#### INTERCEPT
-<code>__INTERCEPT__(data_y, data_x)</code>
-<a class="headerlink" href="#intercept" title="Permanent link">#</a>
+#### <code>__INTERCEPT__(data_y, data_x)</code> {: #intercept }
 </summary>
 Calculates the y-value at which the line resulting from linear regression of a dataset will intersect the y-axis (x=0).
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="kurt" markdown><summary class="unimplemented">
-#### KURT
-<code>__KURT__(value1, value2)</code>
-<a class="headerlink" href="#kurt" title="Permanent link">#</a>
+#### <code>__KURT__(value1, value2)</code> {: #kurt }
 </summary>
 Calculates the kurtosis of a dataset, which describes the shape, and in particular the "peakedness" of that dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="large" markdown><summary class="unimplemented">
-#### LARGE
-<code>__LARGE__(data, n)</code>
-<a class="headerlink" href="#large" title="Permanent link">#</a>
+#### <code>__LARGE__(data, n)</code> {: #large }
 </summary>
 Returns the nth largest element from a data set, where n is user-defined.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="loginv" markdown><summary class="unimplemented">
-#### LOGINV
-<code>__LOGINV__(x, mean, standard_deviation)</code>
-<a class="headerlink" href="#loginv" title="Permanent link">#</a>
+#### <code>__LOGINV__(x, mean, standard_deviation)</code> {: #loginv }
 </summary>
 Returns the value of the inverse log-normal cumulative distribution with given mean and standard deviation at a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="lognormdist" markdown><summary class="unimplemented">
-#### LOGNORMDIST
-<code>__LOGNORMDIST__(x, mean, standard_deviation)</code>
-<a class="headerlink" href="#lognormdist" title="Permanent link">#</a>
+#### <code>__LOGNORMDIST__(x, mean, standard_deviation)</code> {: #lognormdist }
 </summary>
 Returns the value of the log-normal cumulative distribution with given mean and standard deviation at a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="max" markdown><summary >
-#### MAX
-<code>__MAX__(value, *more_values)</code>
-<a class="headerlink" href="#max" title="Permanent link">#</a>
+#### <code>__MAX__(value, *more_values)</code> {: #max }
 </summary>
 Returns the maximum value in a dataset, ignoring values other than numbers and dates/datetimes.
 
@@ -4060,9 +3732,7 @@ datetime.date(2015, 1, 2)
 
 </details>
 <details id="maxa" markdown><summary >
-#### MAXA
-<code>__MAXA__(value, *more_values)</code>
-<a class="headerlink" href="#maxa" title="Permanent link">#</a>
+#### <code>__MAXA__(value, *more_values)</code> {: #maxa }
 </summary>
 Returns the maximum numeric value in a dataset.
 
@@ -4098,9 +3768,7 @@ False as 0. Returns 0 if the arguments contain no numbers.
 
 </details>
 <details id="median" markdown><summary >
-#### MEDIAN
-<code>__MEDIAN__(value, *more_values)</code>
-<a class="headerlink" href="#median" title="Permanent link">#</a>
+#### <code>__MEDIAN__(value, *more_values)</code> {: #median }
 </summary>
 Returns the median value in a numeric dataset, ignoring non-numerical values.
 
@@ -4143,9 +3811,7 @@ ValueError: MEDIAN requires at least one number
 
 </details>
 <details id="min" markdown><summary >
-#### MIN
-<code>__MIN__(value, *more_values)</code>
-<a class="headerlink" href="#min" title="Permanent link">#</a>
+#### <code>__MIN__(value, *more_values)</code> {: #min }
 </summary>
 Returns the minimum value in a dataset, ignoring values other than numbers and dates/datetimes.
 
@@ -4196,9 +3862,7 @@ datetime.datetime(2015, 1, 1, 12, 34, 56)
 
 </details>
 <details id="mina" markdown><summary >
-#### MINA
-<code>__MINA__(value, *more_values)</code>
-<a class="headerlink" href="#mina" title="Permanent link">#</a>
+#### <code>__MINA__(value, *more_values)</code> {: #mina }
 </summary>
 Returns the minimum numeric value in a dataset.
 
@@ -4234,27 +3898,21 @@ False as 0. Returns 0 if the arguments contain no numbers.
 
 </details>
 <details id="mode" markdown><summary class="unimplemented">
-#### MODE
-<code>__MODE__(value1, value2)</code>
-<a class="headerlink" href="#mode" title="Permanent link">#</a>
+#### <code>__MODE__(value1, value2)</code> {: #mode }
 </summary>
 Returns the most commonly occurring value in a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="negbinomdist" markdown><summary class="unimplemented">
-#### NEGBINOMDIST
-<code>__NEGBINOMDIST__(num_failures, num_successes, prob_success)</code>
-<a class="headerlink" href="#negbinomdist" title="Permanent link">#</a>
+#### <code>__NEGBINOMDIST__(num_failures, num_successes, prob_success)</code> {: #negbinomdist }
 </summary>
 Calculates the probability of drawing a certain number of failures before a certain number of successes given a probability of success in independent trials.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="normdist" markdown><summary class="unimplemented">
-#### NORMDIST
-<code>__NORMDIST__(x, mean, standard_deviation, cumulative)</code>
-<a class="headerlink" href="#normdist" title="Permanent link">#</a>
+#### <code>__NORMDIST__(x, mean, standard_deviation, cumulative)</code> {: #normdist }
 </summary>
 Returns the value of the normal distribution function (or normal cumulative distribution
 function) for a specified value, mean, and standard deviation.
@@ -4262,90 +3920,70 @@ function) for a specified value, mean, and standard deviation.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="norminv" markdown><summary class="unimplemented">
-#### NORMINV
-<code>__NORMINV__(x, mean, standard_deviation)</code>
-<a class="headerlink" href="#norminv" title="Permanent link">#</a>
+#### <code>__NORMINV__(x, mean, standard_deviation)</code> {: #norminv }
 </summary>
 Returns the value of the inverse normal distribution function for a specified value, mean, and standard deviation.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="normsdist" markdown><summary class="unimplemented">
-#### NORMSDIST
-<code>__NORMSDIST__(x)</code>
-<a class="headerlink" href="#normsdist" title="Permanent link">#</a>
+#### <code>__NORMSDIST__(x)</code> {: #normsdist }
 </summary>
 Returns the value of the standard normal cumulative distribution function for a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="normsinv" markdown><summary class="unimplemented">
-#### NORMSINV
-<code>__NORMSINV__(x)</code>
-<a class="headerlink" href="#normsinv" title="Permanent link">#</a>
+#### <code>__NORMSINV__(x)</code> {: #normsinv }
 </summary>
 Returns the value of the inverse standard normal distribution function for a specified value.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="pearson" markdown><summary class="unimplemented">
-#### PEARSON
-<code>__PEARSON__(data_y, data_x)</code>
-<a class="headerlink" href="#pearson" title="Permanent link">#</a>
+#### <code>__PEARSON__(data_y, data_x)</code> {: #pearson }
 </summary>
 Calculates r, the Pearson product-moment correlation coefficient of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="percentile" markdown><summary class="unimplemented">
-#### PERCENTILE
-<code>__PERCENTILE__(data, percentile)</code>
-<a class="headerlink" href="#percentile" title="Permanent link">#</a>
+#### <code>__PERCENTILE__(data, percentile)</code> {: #percentile }
 </summary>
 Returns the value at a given percentile of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="percentrank" markdown><summary class="unimplemented">
-#### PERCENTRANK
-<code>__PERCENTRANK__(data, value, significant_digits=None)</code>
-<a class="headerlink" href="#percentrank" title="Permanent link">#</a>
+#### <code>__PERCENTRANK__(data, value, significant_digits=None)</code> {: #percentrank }
 </summary>
 Returns the percentage rank (percentile) of a specified value in a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="percentrank_exc" markdown><summary class="unimplemented">
-#### PERCENTRANK_EXC
-<code>__PERCENTRANK_EXC__(data, value, significant_digits=None)</code>
-<a class="headerlink" href="#percentrank_exc" title="Permanent link">#</a>
+#### <code>__PERCENTRANK_EXC__(data, value, significant_digits=None)</code> {: #percentrank_exc }
 </summary>
 Returns the percentage rank (percentile) from 0 to 1 exclusive of a specified value in a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="percentrank_inc" markdown><summary class="unimplemented">
-#### PERCENTRANK_INC
-<code>__PERCENTRANK_INC__(data, value, significant_digits=None)</code>
-<a class="headerlink" href="#percentrank_inc" title="Permanent link">#</a>
+#### <code>__PERCENTRANK_INC__(data, value, significant_digits=None)</code> {: #percentrank_inc }
 </summary>
 Returns the percentage rank (percentile) from 0 to 1 inclusive of a specified value in a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="permut" markdown><summary class="unimplemented">
-#### PERMUT
-<code>__PERMUT__(n, k)</code>
-<a class="headerlink" href="#permut" title="Permanent link">#</a>
+#### <code>__PERMUT__(n, k)</code> {: #permut }
 </summary>
 Returns the number of ways to choose some number of objects from a pool of a given size of objects, considering order.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="poisson" markdown><summary class="unimplemented">
-#### POISSON
-<code>__POISSON__(x, mean, cumulative)</code>
-<a class="headerlink" href="#poisson" title="Permanent link">#</a>
+#### <code>__POISSON__(x, mean, cumulative)</code> {: #poisson }
 </summary>
 Returns the value of the Poisson distribution function (or Poisson cumulative distribution
 function) for a specified value and mean.
@@ -4353,90 +3991,70 @@ function) for a specified value and mean.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="prob" markdown><summary class="unimplemented">
-#### PROB
-<code>__PROB__(data, probabilities, low_limit, high_limit=None)</code>
-<a class="headerlink" href="#prob" title="Permanent link">#</a>
+#### <code>__PROB__(data, probabilities, low_limit, high_limit=None)</code> {: #prob }
 </summary>
 Given a set of values and corresponding probabilities, calculates the probability that a value chosen at random falls between two limits.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="quartile" markdown><summary class="unimplemented">
-#### QUARTILE
-<code>__QUARTILE__(data, quartile_number)</code>
-<a class="headerlink" href="#quartile" title="Permanent link">#</a>
+#### <code>__QUARTILE__(data, quartile_number)</code> {: #quartile }
 </summary>
 Returns a value nearest to a specified quartile of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="rank_avg" markdown><summary class="unimplemented">
-#### RANK_AVG
-<code>__RANK_AVG__(value, data, is_ascending=None)</code>
-<a class="headerlink" href="#rank_avg" title="Permanent link">#</a>
+#### <code>__RANK_AVG__(value, data, is_ascending=None)</code> {: #rank_avg }
 </summary>
 Returns the rank of a specified value in a dataset. If there is more than one entry of the same value in the dataset, the average rank of the entries will be returned.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="rank_eq" markdown><summary class="unimplemented">
-#### RANK_EQ
-<code>__RANK_EQ__(value, data, is_ascending=None)</code>
-<a class="headerlink" href="#rank_eq" title="Permanent link">#</a>
+#### <code>__RANK_EQ__(value, data, is_ascending=None)</code> {: #rank_eq }
 </summary>
 Returns the rank of a specified value in a dataset. If there is more than one entry of the same value in the dataset, the top rank of the entries will be returned.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="rsq" markdown><summary class="unimplemented">
-#### RSQ
-<code>__RSQ__(data_y, data_x)</code>
-<a class="headerlink" href="#rsq" title="Permanent link">#</a>
+#### <code>__RSQ__(data_y, data_x)</code> {: #rsq }
 </summary>
 Calculates the square of r, the Pearson product-moment correlation coefficient of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="skew" markdown><summary class="unimplemented">
-#### SKEW
-<code>__SKEW__(value1, value2)</code>
-<a class="headerlink" href="#skew" title="Permanent link">#</a>
+#### <code>__SKEW__(value1, value2)</code> {: #skew }
 </summary>
 Calculates the skewness of a dataset, which describes the symmetry of that dataset about the mean.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="slope" markdown><summary class="unimplemented">
-#### SLOPE
-<code>__SLOPE__(data_y, data_x)</code>
-<a class="headerlink" href="#slope" title="Permanent link">#</a>
+#### <code>__SLOPE__(data_y, data_x)</code> {: #slope }
 </summary>
 Calculates the slope of the line resulting from linear regression of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="small" markdown><summary class="unimplemented">
-#### SMALL
-<code>__SMALL__(data, n)</code>
-<a class="headerlink" href="#small" title="Permanent link">#</a>
+#### <code>__SMALL__(data, n)</code> {: #small }
 </summary>
 Returns the nth smallest element from a data set, where n is user-defined.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="standardize" markdown><summary class="unimplemented">
-#### STANDARDIZE
-<code>__STANDARDIZE__(value, mean, standard_deviation)</code>
-<a class="headerlink" href="#standardize" title="Permanent link">#</a>
+#### <code>__STANDARDIZE__(value, mean, standard_deviation)</code> {: #standardize }
 </summary>
 Calculates the normalized equivalent of a random variable given mean and standard deviation of the distribution.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="stdev" markdown><summary >
-#### STDEV
-<code>__STDEV__(value, *more_values)</code>
-<a class="headerlink" href="#stdev" title="Permanent link">#</a>
+#### <code>__STDEV__(value, *more_values)</code> {: #stdev }
 </summary>
 Calculates the standard deviation based on a sample, ignoring non-numerical values.
 
@@ -4470,9 +4088,7 @@ ZeroDivisionError: float division by zero
 
 </details>
 <details id="stdeva" markdown><summary >
-#### STDEVA
-<code>__STDEVA__(value, *more_values)</code>
-<a class="headerlink" href="#stdeva" title="Permanent link">#</a>
+#### <code>__STDEVA__(value, *more_values)</code> {: #stdeva }
 </summary>
 Calculates the standard deviation based on a sample, setting text to the value `0`.
 
@@ -4506,9 +4122,7 @@ ZeroDivisionError: float division by zero
 
 </details>
 <details id="stdevp" markdown><summary >
-#### STDEVP
-<code>__STDEVP__(value, *more_values)</code>
-<a class="headerlink" href="#stdevp" title="Permanent link">#</a>
+#### <code>__STDEVP__(value, *more_values)</code> {: #stdevp }
 </summary>
 Calculates the standard deviation based on an entire population, ignoring non-numerical values.
 
@@ -4540,9 +4154,7 @@ Calculates the standard deviation based on an entire population, ignoring non-nu
 
 </details>
 <details id="stdevpa" markdown><summary >
-#### STDEVPA
-<code>__STDEVPA__(value, *more_values)</code>
-<a class="headerlink" href="#stdevpa" title="Permanent link">#</a>
+#### <code>__STDEVPA__(value, *more_values)</code> {: #stdevpa }
 </summary>
 Calculates the standard deviation based on an entire population, setting text to the value `0`.
 
@@ -4574,108 +4186,84 @@ Calculates the standard deviation based on an entire population, setting text to
 
 </details>
 <details id="steyx" markdown><summary class="unimplemented">
-#### STEYX
-<code>__STEYX__(data_y, data_x)</code>
-<a class="headerlink" href="#steyx" title="Permanent link">#</a>
+#### <code>__STEYX__(data_y, data_x)</code> {: #steyx }
 </summary>
 Calculates the standard error of the predicted y-value for each x in the regression of a dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="tdist" markdown><summary class="unimplemented">
-#### TDIST
-<code>__TDIST__(x, degrees_freedom, tails)</code>
-<a class="headerlink" href="#tdist" title="Permanent link">#</a>
+#### <code>__TDIST__(x, degrees_freedom, tails)</code> {: #tdist }
 </summary>
 Calculates the probability for Student's t-distribution with a given input (x).
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="tinv" markdown><summary class="unimplemented">
-#### TINV
-<code>__TINV__(probability, degrees_freedom)</code>
-<a class="headerlink" href="#tinv" title="Permanent link">#</a>
+#### <code>__TINV__(probability, degrees_freedom)</code> {: #tinv }
 </summary>
 Calculates the inverse of the two-tailed TDIST function.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="trimmean" markdown><summary class="unimplemented">
-#### TRIMMEAN
-<code>__TRIMMEAN__(data, exclude_proportion)</code>
-<a class="headerlink" href="#trimmean" title="Permanent link">#</a>
+#### <code>__TRIMMEAN__(data, exclude_proportion)</code> {: #trimmean }
 </summary>
 Calculates the mean of a dataset excluding some proportion of data from the high and low ends of the dataset.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="ttest" markdown><summary class="unimplemented">
-#### TTEST
-<code>__TTEST__(range1, range2, tails, type)</code>
-<a class="headerlink" href="#ttest" title="Permanent link">#</a>
+#### <code>__TTEST__(range1, range2, tails, type)</code> {: #ttest }
 </summary>
 Returns the probability associated with t-test. Determines whether two samples are likely to have come from the same two underlying populations that have the same mean.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="t_inv" markdown><summary class="unimplemented">
-#### T_INV
-<code>__T_INV__(probability, degrees_freedom)</code>
-<a class="headerlink" href="#t_inv" title="Permanent link">#</a>
+#### <code>__T_INV__(probability, degrees_freedom)</code> {: #t_inv }
 </summary>
 Calculates the negative inverse of the one-tailed TDIST function.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="t_inv_2t" markdown><summary class="unimplemented">
-#### T_INV_2T
-<code>__T_INV_2T__(probability, degrees_freedom)</code>
-<a class="headerlink" href="#t_inv_2t" title="Permanent link">#</a>
+#### <code>__T_INV_2T__(probability, degrees_freedom)</code> {: #t_inv_2t }
 </summary>
 Calculates the inverse of the two-tailed TDIST function.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="var" markdown><summary class="unimplemented">
-#### VAR
-<code>__VAR__(value1, value2)</code>
-<a class="headerlink" href="#var" title="Permanent link">#</a>
+#### <code>__VAR__(value1, value2)</code> {: #var }
 </summary>
 Calculates the variance based on a sample.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="vara" markdown><summary class="unimplemented">
-#### VARA
-<code>__VARA__(value1, value2)</code>
-<a class="headerlink" href="#vara" title="Permanent link">#</a>
+#### <code>__VARA__(value1, value2)</code> {: #vara }
 </summary>
 Calculates an estimate of variance based on a sample, setting text to the value `0`.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="varp" markdown><summary class="unimplemented">
-#### VARP
-<code>__VARP__(value1, value2)</code>
-<a class="headerlink" href="#varp" title="Permanent link">#</a>
+#### <code>__VARP__(value1, value2)</code> {: #varp }
 </summary>
 Calculates the variance based on an entire population.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="varpa" markdown><summary class="unimplemented">
-#### VARPA
-<code>__VARPA__(value1, value2)</code>
-<a class="headerlink" href="#varpa" title="Permanent link">#</a>
+#### <code>__VARPA__(value1, value2)</code> {: #varpa }
 </summary>
 Calculates the variance based on an entire population, setting text to the value `0`.
 
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="weibull" markdown><summary class="unimplemented">
-#### WEIBULL
-<code>__WEIBULL__(x, shape, scale, cumulative)</code>
-<a class="headerlink" href="#weibull" title="Permanent link">#</a>
+#### <code>__WEIBULL__(x, shape, scale, cumulative)</code> {: #weibull }
 </summary>
 Returns the value of the Weibull distribution function (or Weibull cumulative distribution
 function) for a specified shape and scale.
@@ -4683,9 +4271,7 @@ function) for a specified shape and scale.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="ztest" markdown><summary class="unimplemented">
-#### ZTEST
-<code>__ZTEST__(data, value, standard_deviation)</code>
-<a class="headerlink" href="#ztest" title="Permanent link">#</a>
+#### <code>__ZTEST__(data, value, standard_deviation)</code> {: #ztest }
 </summary>
 Returns the two-tailed P-value of a Z-test with standard distribution.
 
@@ -4693,9 +4279,7 @@ Returns the two-tailed P-value of a Z-test with standard distribution.
 </details>
 ### Text
 <details id="char" markdown><summary >
-#### CHAR
-<code>__CHAR__(table_number)</code>
-<a class="headerlink" href="#char" title="Permanent link">#</a>
+#### <code>__CHAR__(table_number)</code> {: #char }
 </summary>
 Convert a number into a character according to the current Unicode table.
 Same as `unichr(number)`.
@@ -4713,9 +4297,7 @@ u'!'
 
 </details>
 <details id="clean" markdown><summary >
-#### CLEAN
-<code>__CLEAN__(text)</code>
-<a class="headerlink" href="#clean" title="Permanent link">#</a>
+#### <code>__CLEAN__(text)</code> {: #clean }
 </summary>
 Returns the text with the non-printable characters removed.
 
@@ -4730,9 +4312,7 @@ u'Monthly report'
 
 </details>
 <details id="code" markdown><summary >
-#### CODE
-<code>__CODE__(string)</code>
-<a class="headerlink" href="#code" title="Permanent link">#</a>
+#### <code>__CODE__(string)</code> {: #code }
 </summary>
 Returns the numeric Unicode map value of the first character in the string provided.
 Same as `ord(string[0])`.
@@ -4755,9 +4335,7 @@ Same as `ord(string[0])`.
 
 </details>
 <details id="concat" markdown><summary >
-#### CONCAT
-<code>__CONCAT__(string, *more_strings)</code>
-<a class="headerlink" href="#concat" title="Permanent link">#</a>
+#### <code>__CONCAT__(string, *more_strings)</code> {: #concat }
 </summary>
 Joins together any number of text strings into one string. Also available under the name
 `CONCATENATE`. Similar to the Python expression `"".join(array_of_strings)`.
@@ -4790,9 +4368,7 @@ u'0abc'
 
 </details>
 <details id="concatenate" markdown><summary >
-#### CONCATENATE
-<code>__CONCATENATE__(string, *more_strings)</code>
-<a class="headerlink" href="#concatenate" title="Permanent link">#</a>
+#### <code>__CONCATENATE__(string, *more_strings)</code> {: #concatenate }
 </summary>
 Joins together any number of text strings into one string. Also available under the name
 `CONCAT`. Similar to the Python expression `"".join(array_of_strings)`.
@@ -4835,9 +4411,7 @@ u'0abc'
 
 </details>
 <details id="dollar" markdown><summary >
-#### DOLLAR
-<code>__DOLLAR__(number, decimals=2)</code>
-<a class="headerlink" href="#dollar" title="Permanent link">#</a>
+#### <code>__DOLLAR__(number, decimals=2)</code> {: #dollar }
 </summary>
 Formats a number into a formatted dollar amount, with decimals rounded to the specified place (.
 If decimals value is omitted, it defaults to 2.
@@ -4880,9 +4454,7 @@ If decimals value is omitted, it defaults to 2.
 
 </details>
 <details id="exact" markdown><summary >
-#### EXACT
-<code>__EXACT__(string1, string2)</code>
-<a class="headerlink" href="#exact" title="Permanent link">#</a>
+#### <code>__EXACT__(string1, string2)</code> {: #exact }
 </summary>
 Tests whether two strings are identical. Same as `string2 == string2`.
 
@@ -4904,9 +4476,7 @@ False
 
 </details>
 <details id="find" markdown><summary >
-#### FIND
-<code>__FIND__(find_text, within_text, start_num=1)</code>
-<a class="headerlink" href="#find" title="Permanent link">#</a>
+#### <code>__FIND__(find_text, within_text, start_num=1)</code> {: #find }
 </summary>
 Returns the position at which a string is first found within text.
 
@@ -4963,9 +4533,7 @@ ValueError: substring not found
 
 </details>
 <details id="fixed" markdown><summary >
-#### FIXED
-<code>__FIXED__(number, decimals=2, no_commas=False)</code>
-<a class="headerlink" href="#fixed" title="Permanent link">#</a>
+#### <code>__FIXED__(number, decimals=2, no_commas=False)</code> {: #fixed }
 </summary>
 Formats a number with a fixed number of decimal places (2 by default), and commas.
 If no_commas is True, then omits the commas.
@@ -5013,9 +4581,7 @@ If no_commas is True, then omits the commas.
 
 </details>
 <details id="left" markdown><summary >
-#### LEFT
-<code>__LEFT__(string, num_chars=1)</code>
-<a class="headerlink" href="#left" title="Permanent link">#</a>
+#### <code>__LEFT__(string, num_chars=1)</code> {: #left }
 </summary>
 Returns a substring of length num_chars from the beginning of the given string. If num_chars is
 omitted, it is assumed to be 1. Same as `string[:num_chars]`.
@@ -5040,9 +4606,7 @@ ValueError: num_chars invalid
 
 </details>
 <details id="len" markdown><summary >
-#### LEN
-<code>__LEN__(text)</code>
-<a class="headerlink" href="#len" title="Permanent link">#</a>
+#### <code>__LEN__(text)</code> {: #len }
 </summary>
 Returns the number of characters in a text string, or the number of items in a list. Same as
 [`len`](https://docs.python.org/3/library/functions.html#len) in python.
@@ -5066,9 +4630,7 @@ See [Record Set](#recordset) for an example of using `len` on a list of records.
 
 </details>
 <details id="lower" markdown><summary >
-#### LOWER
-<code>__LOWER__(text)</code>
-<a class="headerlink" href="#lower" title="Permanent link">#</a>
+#### <code>__LOWER__(text)</code> {: #lower }
 </summary>
 Converts a specified string to lowercase. Same as `text.lower()`.
 
@@ -5085,9 +4647,7 @@ Converts a specified string to lowercase. Same as `text.lower()`.
 
 </details>
 <details id="mid" markdown><summary >
-#### MID
-<code>__MID__(text, start_num, num_chars)</code>
-<a class="headerlink" href="#mid" title="Permanent link">#</a>
+#### <code>__MID__(text, start_num, num_chars)</code> {: #mid }
 </summary>
 Returns a segment of a string, starting at start_num. The first character in text has
 start_num 1.
@@ -5117,9 +4677,7 @@ ValueError: start_num invalid
 
 </details>
 <details id="phone_format" markdown><summary >
-#### PHONE_FORMAT
-<code>__PHONE_FORMAT__(value, country=None, format=None)</code>
-<a class="headerlink" href="#phone_format" title="Permanent link">#</a>
+#### <code>__PHONE_FORMAT__(value, country=None, format=None)</code> {: #phone_format }
 </summary>
 Formats a phone number.
 
@@ -5223,9 +4781,7 @@ TypeError: Phone number must be a text value. If formatting a value from a Numer
 
 </details>
 <details id="proper" markdown><summary >
-#### PROPER
-<code>__PROPER__(text)</code>
-<a class="headerlink" href="#proper" title="Permanent link">#</a>
+#### <code>__PROPER__(text)</code> {: #proper }
 </summary>
 Capitalizes each word in a specified string. It converts the first letter of each word to
 uppercase, and all other letters to lowercase. Same as `text.title()`.
@@ -5248,9 +4804,7 @@ uppercase, and all other letters to lowercase. Same as `text.title()`.
 
 </details>
 <details id="regexextract" markdown><summary >
-#### REGEXEXTRACT
-<code>__REGEXEXTRACT__(text, regular_expression)</code>
-<a class="headerlink" href="#regexextract" title="Permanent link">#</a>
+#### <code>__REGEXEXTRACT__(text, regular_expression)</code> {: #regexextract }
 </summary>
 Extracts the first part of text that matches regular_expression.
 
@@ -5281,9 +4835,7 @@ ValueError: REGEXEXTRACT text does not match
 
 </details>
 <details id="regexmatch" markdown><summary >
-#### REGEXMATCH
-<code>__REGEXMATCH__(text, regular_expression)</code>
-<a class="headerlink" href="#regexmatch" title="Permanent link">#</a>
+#### <code>__REGEXMATCH__(text, regular_expression)</code> {: #regexmatch }
 </summary>
 Returns whether a piece of text matches a regular expression.
 
@@ -5315,9 +4867,7 @@ False
 
 </details>
 <details id="regexreplace" markdown><summary >
-#### REGEXREPLACE
-<code>__REGEXREPLACE__(text, regular_expression, replacement)</code>
-<a class="headerlink" href="#regexreplace" title="Permanent link">#</a>
+#### <code>__REGEXREPLACE__(text, regular_expression, replacement)</code> {: #regexreplace }
 </summary>
 Replaces all parts of text matching the given regular expression with replacement text.
 
@@ -5349,9 +4899,7 @@ Replaces all parts of text matching the given regular expression with replacemen
 
 </details>
 <details id="replace" markdown><summary >
-#### REPLACE
-<code>__REPLACE__(text, position, length, new_text)</code>
-<a class="headerlink" href="#replace" title="Permanent link">#</a>
+#### <code>__REPLACE__(text, position, length, new_text)</code> {: #replace }
 </summary>
 Replaces part of a text string with a different text string. Position is counted from 1.
 
@@ -5385,9 +4933,7 @@ ValueError: position invalid
 
 </details>
 <details id="rept" markdown><summary >
-#### REPT
-<code>__REPT__(text, number_times)</code>
-<a class="headerlink" href="#rept" title="Permanent link">#</a>
+#### <code>__REPT__(text, number_times)</code> {: #rept }
 </summary>
 Returns specified text repeated a number of times. Same as `text * number_times`.
 
@@ -5431,9 +4977,7 @@ ValueError: number_times invalid
 
 </details>
 <details id="right" markdown><summary >
-#### RIGHT
-<code>__RIGHT__(string, num_chars=1)</code>
-<a class="headerlink" href="#right" title="Permanent link">#</a>
+#### <code>__RIGHT__(string, num_chars=1)</code> {: #right }
 </summary>
 Returns a substring of length num_chars from the end of a specified string. If num_chars is
 omitted, it is assumed to be 1. Same as `string[-num_chars:]`.
@@ -5463,9 +5007,7 @@ ValueError: num_chars invalid
 
 </details>
 <details id="search" markdown><summary >
-#### SEARCH
-<code>__SEARCH__(find_text, within_text, start_num=1)</code>
-<a class="headerlink" href="#search" title="Permanent link">#</a>
+#### <code>__SEARCH__(find_text, within_text, start_num=1)</code> {: #search }
 </summary>
 Returns the position at which a string is first found within text, ignoring case.
 
@@ -5507,9 +5049,7 @@ If find_text is not found, or start_num is invalid, raises ValueError.
 
 </details>
 <details id="substitute" markdown><summary >
-#### SUBSTITUTE
-<code>__SUBSTITUTE__(text, old_text, new_text, instance_num=None)</code>
-<a class="headerlink" href="#substitute" title="Permanent link">#</a>
+#### <code>__SUBSTITUTE__(text, old_text, new_text, instance_num=None)</code> {: #substitute }
 </summary>
 Replaces existing text with new text in a string. It is useful when you know the substring of
 text to replace. Use REPLACE when you know the position of text to replace.
@@ -5536,9 +5076,7 @@ u'Quarter 1, 2012'
 ```
 </details>
 <details id="t" markdown><summary >
-#### T
-<code>__T__(value)</code>
-<a class="headerlink" href="#t" title="Permanent link">#</a>
+#### <code>__T__(value)</code> {: #t }
 </summary>
 Returns value if value is text, or the empty string when value is not text.
 
@@ -5580,9 +5118,7 @@ u''
 
 </details>
 <details id="tasteme" markdown><summary >
-#### TASTEME
-<code>__TASTEME__(food)</code>
-<a class="headerlink" href="#tasteme" title="Permanent link">#</a>
+#### <code>__TASTEME__(food)</code> {: #tasteme }
 </summary>
 For any given piece of text, decides if it is tasty or not.
 
@@ -5603,9 +5139,7 @@ False
 
 </details>
 <details id="text" markdown><summary class="unimplemented">
-#### TEXT
-<code>__TEXT__(number, format_type)</code>
-<a class="headerlink" href="#text" title="Permanent link">#</a>
+#### <code>__TEXT__(number, format_type)</code> {: #text }
 </summary>
 Converts a number into text according to a specified format. It is not yet implemented in
 Grist. You can use the similar Python functions str() to convert numbers into strings, and
@@ -5614,9 +5148,7 @@ optionally format() to specify the number format.
 <span class="grist-tip">Note</span>This function is not currently implemented in Grist.
 </details>
 <details id="trim" markdown><summary >
-#### TRIM
-<code>__TRIM__(text)</code>
-<a class="headerlink" href="#trim" title="Permanent link">#</a>
+#### <code>__TRIM__(text)</code> {: #trim }
 </summary>
 Removes all spaces from text except for single spaces between words. Note that TRIM does not
 remove other whitespace such as tab or newline characters.
@@ -5634,9 +5166,7 @@ remove other whitespace such as tab or newline characters.
 
 </details>
 <details id="upper" markdown><summary >
-#### UPPER
-<code>__UPPER__(text)</code>
-<a class="headerlink" href="#upper" title="Permanent link">#</a>
+#### <code>__UPPER__(text)</code> {: #upper }
 </summary>
 Converts a specified string to uppercase. Same as `text.upper()`.
 
@@ -5653,9 +5183,7 @@ Converts a specified string to uppercase. Same as `text.upper()`.
 
 </details>
 <details id="value" markdown><summary >
-#### VALUE
-<code>__VALUE__(text)</code>
-<a class="headerlink" href="#value" title="Permanent link">#</a>
+#### <code>__VALUE__(text)</code> {: #value }
 </summary>
 Converts a string in accepted date, time or number formats into a number or date.
 

--- a/help/en/docs/js/grist.js
+++ b/help/en/docs/js/grist.js
@@ -6,23 +6,14 @@
 function expandSelected() {
   var hash = window.location.hash.split('/').slice(-1)[0];
   var elem = hash ? document.querySelector(hash) : null;
-  var elemToTest = elem;
-  // Find an expandable parent node.
-  while (elemToTest) {
-    if (elemToTest && elemToTest.tagName === 'DETAILS') {
-      break;
-    }
-    elemToTest = elemToTest.parentElement;
-  }
+  var closestExpandableElem = elem.closest('details');
 
-  if (!elemToTest) {
+  if (!closestExpandableElem) {
     return;
   }
 
-  var elemToExpand = elemToTest;
-
   for (var el of document.querySelectorAll('details')) {
-    el.open = (el === elemToExpand);
+    el.open = (el === closestExpandableElem);
   }
 
   // After collapsing other details, the scroll position may be off, so fix it now.

--- a/help/en/docs/js/grist.js
+++ b/help/en/docs/js/grist.js
@@ -6,13 +6,27 @@
 function expandSelected() {
   var hash = window.location.hash.split('/').slice(-1)[0];
   var elem = hash ? document.querySelector(hash) : null;
-  if (elem && elem.tagName === 'DETAILS') {
-    for (var el of document.querySelectorAll('details')) {
-      el.open = (el === elem);
+  var elemToTest = elem;
+  // Find an expandable parent node.
+  while (elemToTest) {
+    if (elemToTest && elemToTest.tagName === 'DETAILS') {
+      break;
     }
-    // After collapsing other details, the scroll position may be off, so fix it now.
-    elem.scrollIntoView();
+    elemToTest = elemToTest.parentElement;
   }
+
+  if (!elemToTest) {
+    return;
+  }
+
+  var elemToExpand = elemToTest;
+
+  for (var el of document.querySelectorAll('details')) {
+    el.open = (el === elemToExpand);
+  }
+
+  // After collapsing other details, the scroll position may be off, so fix it now.
+  elem.scrollIntoView();
 }
 
 // Function to get and auto play YouTube video from data tag.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -214,6 +214,7 @@ markdown_extensions:
   smarty: {}
   extra: {}
   meta: {}
+  attr_list: {}
 
 hooks:
 - ../../mkdocs-utils/hooks.py

--- a/mkpydocs.py
+++ b/mkpydocs.py
@@ -148,10 +148,8 @@ def get_doc_text(docitems):
     output.append('### ' + category)
     for d in items:
       css_class = 'class="unimplemented"' if d.is_unimplemented else ""
-      output.append('<details id="%s" markdown><summary %s>' % (d.anchor, css_class))
-      output.append('#### %s' % d.names[0])
-      output.append('<code>%s</code>' % (d.usage,))
-      output.append('<a class="headerlink" href="#%s" title="Permanent link">#</a>' % d.anchor)
+      output.append(f'<details markdown><summary {css_class}>')
+      output.append(f'#### <code>{d.usage}</code> {{: #{d.anchor} data-toc-label="{d.names[0]}" }}')
       output.append('</summary>')
       output.extend(d.format_doc())
       if d.is_unimplemented:


### PR DESCRIPTION
This PR:
- Reworks how function names are rendered on the functions page, meaning we don't need a hidden header element.
- Adds attr_list as an extension (I think it should always have been there?)
- Adds styling to make the (now visible) header elements match what was there before.
- Fixes sections not expanding when jumped to via permalink or searching