### PR TITLE
Move admonition to the top of the page

### DIFF
--- a/mkdocs-utils/hooks.py
+++ b/mkdocs-utils/hooks.py
@@ -113,12 +113,7 @@ def _inject_warning(markdown: str, warning: str, page: Page):
   for excluded_section in non_translated_sections:
     if page.file.src_path.startswith(excluded_section):
       return markdown
-  missing_translation_content = warning
-  header = ""
-  body = markdown
-  if markdown.startswith("#"):
-    header, _, body = markdown.partition("\n\n")
-  return f"{header}\n\n{missing_translation_content}\n\n{body}"
+  return f"{warning}\n\n{markdown}"
 
 def on_page_markdown(
   markdown: str, *, page: Page, config: MkDocsConfig, **_: Any


### PR DESCRIPTION
## Context

The admonition is thought to be displayed after the title of the page.

However, there are some glitch, where the admonition is displayed before the titles, like on the page about the [column types](https://support.getgrist.com/fr/col-types/), and sometimes even they do not appear at all, like the [functions reference](https://support.getgrist.com/fr/functions/) (don't take a look at the rendering, this is another PR I will submit ASAP).

## Proposed solution

I would say it is fine to display the admonition at the top, before the title. It simplifies the code.