### PR TITLE
Include extra info for webhook "Ready column" parameter usage

### DIFF
--- a/help/en/docs/webhooks.md
+++ b/help/en/docs/webhooks.md
@@ -46,9 +46,7 @@ the processing of the webhook. Not all fields are required.
   triggers when adding a row, it does not matter which columns are defined
   when the new row is added.
 * **Ready column** (optional): A boolean, or [Toggle](col-types.md#toggle-columns), column on the table that
-  determines if the row should trigger the webhook or not. When the
-  column becomes true, the corresponding row will trigger the webhook.
-  Rows become visibile to the webhook only when "Ready column" is first set to true. For this reason, we need both "add" and "update" event types selected for it to work.
+  determines if the row is visible to webhooks. While the toggle in the "Ready column" is false, changes to that row do not trigger the webhook. When the column becomes true, the row becomes visible to the webhook, and triggers the "add" event. While the column is true, further changes to the row trigger "update" events.
 * **URL**: The remote URL of the service that the webhook will notify
   of added or changed rows. When self-hosting, only external services
   listed by the [`ALLOWED_WEBHOOK_DOMAINS` environment variable](

--- a/help/en/docs/webhooks.md
+++ b/help/en/docs/webhooks.md
@@ -48,6 +48,7 @@ the processing of the webhook. Not all fields are required.
 * **Ready column** (optional): A boolean, or [Toggle](col-types.md#toggle-columns), column on the table that
   determines if the row should trigger the webhook or not. When the
   column becomes true, the corresponding row will trigger the webhook.
+  Rows become visibile to the webhook only when "Ready column" is first set to true. For this reason, we need both "add" and "update" event types selected for it to work.
 * **URL**: The remote URL of the service that the webhook will notify
   of added or changed rows. When self-hosting, only external services
   listed by the [`ALLOWED_WEBHOOK_DOMAINS` environment variable](


### PR DESCRIPTION
When trying to use webhooks with "Ready column" option, I couldn't make it work. I asked help for the Grist team and they explained that:

"The second issue, with the "Ready" column not triggering, can be resolved by updating your "Event Types" to include "add" (in addition to "update"). The reason for this is because the “Ready” column actually determines whether the webhook logic sees the record as existing or not existing. So a change to the “Ready” column is seen as an “Add” event. Once “Ready” is true, then other changes to the same record are seen as “Update” events."

Thanks Natalie White for the explanation.

To help the next user, I'd like to include the core of this explanation on the webhook help page.
