### PR TITLE
fix some broken marketplace-related links

### DIFF
--- a/help/en/docs/install/aws-marketplace-legacy.md
+++ b/help/en/docs/install/aws-marketplace-legacy.md
@@ -2,7 +2,7 @@ AWS Marketplace (Legacy) {: .tag-core .tag-ee }
 =============
 
 !!! warning "Note"
-    This documentation refers to the legacy version of Grist on the AWS Marketplace, based on [Grist Omnibus](https://github.com/gristlabs/grist-omnibus). You can find the documentation for the current offering [here](aws-marketplace.md). Also consult, our [transitioning notes](aws-marketplace-transition.md).
+    This documentation refers to the legacy version of Grist on the AWS Marketplace, based on [Grist Omnibus](https://github.com/gristlabs/grist-omnibus). You can find the documentation for the current offering [here](grist-builder-edition.md). Also consult, our [transitioning notes](aws-marketplace-transition.md).
 
 ## First run setup
 
@@ -29,7 +29,7 @@ Once the above steps are completed, you should be able to access Grist on your c
 
 ## Authentication setup
 
-Once you have [your Microsoft or Google client ID and secret](aws-marketplace.md#authentication-setup), you’ll need to pass them to the `gristParameters` file inside the Grist EC2 instance:
+Once you have [your Microsoft or Google client ID and secret](grist-builder-edition.md#authentication-setup), you’ll need to pass them to the `gristParameters` file inside the Grist EC2 instance:
 
 1. Log in to the Grist EC2 instance.
 2. Open `~/grist/gristParameters`.

--- a/help/en/docs/install/aws-marketplace-transition.md
+++ b/help/en/docs/install/aws-marketplace-transition.md
@@ -9,7 +9,7 @@ Omnibus.
 It is possible to copy your Grist documents to Builder Edition.
 
 1. Take note of the `EMAIL` variable under `~/grist/gristParameters`.
-2. Start [a Grist Builder Edition instance](aws-marketplace.md).
+2. Start [a Grist Builder Edition instance](grist-builder-edition.md).
 3. Follow [the instructions to run the bootstrap
    script](https://github.com/gristlabs/grist-pack/tree/main/dist#quickstart),
    using the value of `EMAIL` for the `DEFAULT_EMAIL` value. See


### PR DESCRIPTION
Ran across a broken link. Fixed these warnings during build:
```
WARNING:mkdocs.structure.pages:Doc file 'install/aws-marketplace-legacy.md' contains a relative link 'aws-marketplace.md', but the target 'install/aws-marketplace.md' is not found among documentation files.
WARNING:mkdocs.structure.pages:Doc file 'install/aws-marketplace-legacy.md' contains a relative link 'aws-marketplace.md#authentication-setup', but the target 'install/aws-marketplace.md' is not found among documentation files.
WARNING:mkdocs.structure.pages:Doc file 'install/aws-marketplace-transition.md' contains a relative link 'aws-marketplace.md', but the target 'install/aws-marketplace.md' is not found among documentation files.
```