### PR TITLE
[FIX] Remove tab character after property in users.yml

### DIFF
--- a/api/scim/users.yml
+++ b/api/scim/users.yml
@@ -405,7 +405,7 @@ components:
           meta:
             type: object
             properties:
-              resourceType:	
+              resourceType:
                 type: string
                 enum: 
                 - "User"


### PR DESCRIPTION
This tab character causes problems parsing the file when using [openapi-generator](https://github.com/OpenAPITools/openapi-generator).