### PR TITLE
api docs: fix sort options

### DIFF
--- a/api/grist.yml
+++ b/api/grist.yml
@@ -2299,7 +2299,7 @@ components:
       name: sort
       schema:
         type: string
-      description: "Order in which to return results. If a single column name is given (e.g. `pet`), results are placed in ascending order of values in that column. To get results in an order that was previously prepared manually in Grist, use the special `manualSort` column name. Multiple columns can be specified, separated by commas (e.g. `pet,age`). For descending order, prefix a column name with a `-` character (e.g. `pet,-age`). To include additional sorting options append them after a colon (e.g. `pet,-age:naturalSort;emptyFirst,owner`). Available options are: `choiceOrder`, `naturalSort`, `emptyFirst`. Without the `sort` parameter, the order of results is unspecified."
+      description: "Order in which to return results. If a single column name is given (e.g. `pet`), results are placed in ascending order of values in that column. To get results in an order that was previously prepared manually in Grist, use the special `manualSort` column name. Multiple columns can be specified, separated by commas (e.g. `pet,age`). For descending order, prefix a column name with a `-` character (e.g. `pet,-age`). To include additional sorting options append them after a colon (e.g. `pet,-age:naturalSort;emptyFirst,owner`). Available options are: `orderByChoice`, `naturalSort`, `emptyFirst`. Without the `sort` parameter, the order of results is unspecified."
       example: "pet,-age"
       required: false
     limitQueryParam:

--- a/api/grist.yml
+++ b/api/grist.yml
@@ -2299,7 +2299,7 @@ components:
       name: sort
       schema:
         type: string
-      description: "Order in which to return results. If a single column name is given (e.g. `pet`), results are placed in ascending order of values in that column. To get results in an order that was previously prepared manually in Grist, use the special `manualSort` column name. Multiple columns can be specified, separated by commas (e.g. `pet,age`). For descending order, prefix a column name with a `-` character (e.g. `pet,-age`). To include additional sorting options append them after a colon (e.g. `pet,-age:naturalSort;emptyFirst,owner`). Available options are: `orderByChoice`, `naturalSort`, `emptyFirst`. Without the `sort` parameter, the order of results is unspecified."
+      description: "Order in which to return results. If a single column name is given (e.g. `pet`), results are placed in ascending order of values in that column. To get results in an order that was previously prepared manually in Grist, use the special `manualSort` column name. Multiple columns can be specified, separated by commas (e.g. `pet,age`). For descending order, prefix a column name with a `-` character (e.g. `pet,-age`). To include additional sorting options append them after a colon (e.g. `pet,-age:naturalSort;emptyLast,owner`). Available options are: `orderByChoice`, `naturalSort`, `emptyLast`. Without the `sort` parameter, the order of results is unspecified."
       example: "pet,-age"
       required: false
     limitQueryParam:


### PR DESCRIPTION
I couldn't get `choiceOrder` to work, so found its actually `orderByChoice`. Found another error in the same place

correct values in the source [here](https://github.com/gristlabs/grist-core/blob/7a09adcf0b1838667bba4a585403a95169df38c4/app/client/ui/SortConfig.ts#L153)