### PR TITLE
Fix typo in cloud-storage.md

### DIFF
--- a/help/en/docs/install/cloud-storage.md
+++ b/help/en/docs/install/cloud-storage.md
@@ -90,5 +90,5 @@ You can control the frequency of snapshots with the following environment variab
     * `isoWeek` - The last N weeks to keep the most recent snapshot for.
     * `month` - The last N months to keep the most recent snapshot for.
     * `year` - The last N years to keep the most recent snapshot for.
-  * `GRIST_SNAPSHOT_KEEP` - Maximum number of recent snapshots to keep, regardless of
+  * `GRIST_SNAPSHOT_KEEP` - Minimum number of recent snapshots to keep, regardless of
   `GRIST_SNAPSHOT_TIME_CAP`. (Default: 5)


### PR DESCRIPTION
My understanding of this variable is that it is a minimum number of snapshots to keep, regardless of the rest