### PR TITLE
Re-generate keyboard shortcuts from code.

### DIFF
--- a/help/en/docs/keyboard-shortcuts.md
+++ b/help/en/docs/keyboard-shortcuts.md
@@ -4,6 +4,7 @@ title: Keyboard shortcuts
 
 # Grist Shortcuts
 
+<!-- The content below is generated from Grist code using ./build-shortcuts.js. -->
 <!-- START -->
 ###General
 | Key (Mac) | Key (Windows) | Description | 
@@ -32,9 +33,10 @@ title: Keyboard shortcuts
 | <code class="keys">*End*</code> | <code class="keys">*End*</code> | Move to the last field or the end of a row |
 | <code class="keys">*⌥* *↓*</code> | <code class="keys">*Alt* + *↓*</code> | Open next page |
 | <code class="keys">*⌥* *↑*</code> | <code class="keys">*Alt* + *↑*</code> | Open previous page |
-| <code class="keys">*⌘* *O*</code> | <code class="keys">*Ctrl* + *O*</code> | Activate next page widget |
-| <code class="keys">*⌘* *⇧* *O*</code> | <code class="keys">*Ctrl* + *Shift* + *O*</code> | Activate previous page widget |
-| <code class="keys">*Space*</code> | <code class="keys">*Space*</code> | Opens a record card in a table widget |
+| <code class="keys">*⌘* *O*</code> | <code class="keys">*Ctrl* + *O*</code> | Focus next page panel or widget |
+| <code class="keys">*⌘* *⇧* *O*</code> | <code class="keys">*Ctrl* + *Shift* + *O*</code> | Focus previous page panel or widget |
+| <code class="keys">*⌘* *⌥* *O*</code> | <code class="keys">*Ctrl* + *Alt* + *O*</code> | Toggle creator panel keyboard focus |
+| <code class="keys">*Space*</code> | <code class="keys">*Space*</code> | Show the record card widget of the selected record |
 
 ###Selection
 | Key (Mac) | Key (Windows) | Description | 
@@ -43,11 +45,11 @@ title: Keyboard shortcuts
 | <code class="keys">*⇧* *↑*</code> | <code class="keys">*Shift* + *↑*</code> | Adds the element above the cursor to the selected range |
 | <code class="keys">*⇧* *→*</code> | <code class="keys">*Shift* + *→*</code> | Adds the element to the right of the cursor to the selected range |
 | <code class="keys">*⇧* *←*</code> | <code class="keys">*Shift* + *←*</code> | Adds the element to the left of the cursor to the selected range |
+| <code class="keys">*⌘* *⇧* *↓*</code> | <code class="keys">*Ctrl* + *Shift* + *↓*</code> | Adds all elements below the cursor to the selected range |
+| <code class="keys">*⌘* *⇧* *↑*</code> | <code class="keys">*Ctrl* + *Shift* + *↑*</code> | Adds all elements above the cursor to the selected range |
+| <code class="keys">*⌘* *⇧* *→*</code> | <code class="keys">*Ctrl* + *Shift* + *→*</code> | Adds all elements to the right of the cursor to the selected range |
+| <code class="keys">*⌘* *⇧* *←*</code> | <code class="keys">*Ctrl* + *Shift* + *←*</code> | Adds all elements to the left of the cursor to the selected range |
 | <code class="keys">*⌘* *A*</code> | <code class="keys">*Ctrl* + *A*</code> | Selects all currently displayed cells |
-| <code class="keys">*⌘* *Shift* *↑*</code> | <code class="keys">*Ctrl* + *Shift* + *↑*</code> | Selects cells above the selected cell in the same column |
-| <code class="keys">*⌘* *Shift* *↓*</code> | <code class="keys">*Ctrl* + *Shift* + *↓*</code> | Selects cells below the selected cell in the same column |
-| <code class="keys">*⌘* *Shift* *→*</code> | <code class="keys">*Ctrl* + *Shift* + *→*</code> | Selects cells to the right of the selected cell in the same row |
-| <code class="keys">*⌘* *Shift* *←*</code> | <code class="keys">*Ctrl* + *Shift* + *←*</code> | Selects cells to the left of the selected cell in the same row |
 | <code class="keys">*⌘* *⇧* *A*</code> | <code class="keys">*Ctrl* + *Shift* + *A*</code> | Copy anchor link |
 
 ###Editing
@@ -55,13 +57,17 @@ title: Keyboard shortcuts
 | - | - | - | 
 | <code class="keys">*Enter*</code>,<code class="keys">*F2*</code> | <code class="keys">*Enter*</code>,<code class="keys">*F2*</code> | Start editing the currently-selected cell |
 | <code class="keys">*Enter*</code> | <code class="keys">*Enter*</code> | Finish editing a cell, saving the value |
+| <code class="keys">*Enter*</code> | <code class="keys">*Enter*</code> | Toggle the currently selected checkbox or switch cell |
 | <code class="keys">*Escape*</code> | <code class="keys">*Escape*</code> | Discard changes to a cell value |
+| <code class="keys">*⌘* *C*</code> | <code class="keys">*Ctrl* + *C*</code> | Copy current selection to clipboard |
+| <code class="keys">*⌘* *X*</code> | <code class="keys">*Ctrl* + *X*</code> | Cut current selection to clipboard |
+| <code class="keys">*⌘* *V*</code> | <code class="keys">*Ctrl* + *V*</code> | Paste clipboard contents at cursor |
 | <code class="keys">*⌘* *D*</code> | <code class="keys">*Ctrl* + *D*</code> | Fills current selection with the contents of the top row in the selection |
 | <code class="keys">*Delete*</code> | <code class="keys">*Backspace*</code>,<code class="keys">*Delete*</code> | Clears the currently selected cells |
-| <code class="keys">*Enter*</code> | <code class="keys">*Enter*</code> | Toggles the value of checkbox cells |
 | <code class="keys">*=*</code> | <code class="keys">*=*</code> | When typed at the start of a cell, make this a formula column |
 | <code class="keys">*⌘* *;*</code> | <code class="keys">*Ctrl* + *;*</code> | Insert the current date |
 | <code class="keys">*⌘* *⇧* *;*</code> | <code class="keys">*Ctrl* + *Shift* + *;*</code> | Insert the current date and time |
+| <code class="keys">*⌘* *⌥* *M*</code> | <code class="keys">*Ctrl* + *Alt* + *M*</code> | Open comment thread |
 
 ###Data manipulation
 | Key (Mac) | Key (Windows) | Description | 
@@ -72,8 +78,9 @@ title: Keyboard shortcuts
 | <code class="keys">*⌘* *Delete*</code> | <code class="keys">*Ctrl* + *Backspace*</code>,<code class="keys">*Ctrl* + *Delete*</code> | Delete the currently selected record(s) |
 | <code class="keys">*⌥* *⇧* *=*</code> | <code class="keys">*Alt* + *Shift* + *=*</code> | Insert a new column, before the currently selected one |
 | <code class="keys">*⌥* *=*</code> | <code class="keys">*Alt* + *=*</code> | Insert a new column, after the currently selected one |
+| <code class="keys">*⌘* *⇧* *H*</code> | <code class="keys">*Ctrl* + *Shift* + *H*</code> | Use the currently selected row as table headers |
 | <code class="keys">*⌃* *M*</code> | <code class="keys">*Ctrl* + *M*</code> | Rename the currently selected column |
-| <code class="keys">*⌥* *⇧* *-*</code> | <code class="keys">*Alt* + *Shift* + *-*</code> | Hide the currently selected column |
+| <code class="keys">*⌥* *⇧* *-*</code> | <code class="keys">*Alt* + *Shift* + *-*</code> | Hide the currently selected columns |
 | <code class="keys">*⌥* *-*</code> | <code class="keys">*Alt* + *-*</code> | Delete the currently selected columns |
 
 <!-- END -->


### PR DESCRIPTION
- This includes some changes in code, to be committed separately.
- Updates the generating script to show usage, use built Grist code, and process shortcuts so as to match the preferred Help Center output (e.g. Del -> Delete).