### PR TITLE
Dev env: reload server when changing theme files

### DIFF
--- a/docs.py
+++ b/docs.py
@@ -268,7 +268,7 @@ def live(
   lang_path: Path = docs_path / lang
   os.chdir(lang_path)
   os.environ["DISABLE_LANGUAGE_SELECTOR"] = "true"
-  mkdocs.commands.serve.serve(dev_addr="127.0.0.1:8000")
+  mkdocs.commands.serve.serve(dev_addr="127.0.0.1:8000", watch_theme=True)
 
 
 def get_updated_alternate_lang_config_content() -> Dict[str, Any]:


### PR DESCRIPTION
Before that, modifying, for example, html files placed in the overrides directory, didn't trigger a rebuild. This made working on the theme a bit tedious, requiring manual rebuilds after every change.