### PR TITLE
Removal of double API in path

### DIFF
--- a/api/grist.yml
+++ b/api/grist.yml
@@ -878,7 +878,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/DocumentStoreSetting'
 
-  /api/docs/{docId}/attachments/transferAll:
+  /docs/{docId}/attachments/transferAll:
     post:
       operationId: startAttachmentTransfer
       tags:
@@ -894,7 +894,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AttachmentsTransferStatus'
 
-  /api/docs/{docId}/attachments/transferStatus:
+  /docs/{docId}/attachments/transferStatus:
     get:
       operationId: getAttachmentTransferStatus
       tags:
@@ -911,7 +911,7 @@ paths:
                 $ref: '#/components/schemas/AttachmentsTransferStatus'
 
 
-  /api/docs/{docId}/attachments/removeUnused:
+  /docs/{docId}/attachments/removeUnused:
     post:
       operationId: removeUnusedAttachments
       tags:


### PR DESCRIPTION
The /api/ part of the path is already defined in row 13. This causes the API console to fail because the path ends up like …/api/api/docs/… should be …/api/docs/…

This was present on the endpoints:
attachments/transferAll:
attachments/transferStatus
attachments/removeUnused