### PR TITLE
Document SCIM groups and Roles

### DIFF
--- a/api/grist.yml
+++ b/api/grist.yml
@@ -1677,6 +1677,16 @@ paths:
     $ref: "./scim/serviceproviderconfig.yml#/paths/~1scim~1v2~1ServiceProviderConfig"
   /scim/v2/ResourceTypes:
     $ref: "./scim/serviceproviderconfig.yml#/paths/~1scim~1v2~1ResourceTypes"
+  /scim/v2/Groups:
+    $ref: "./scim/groups.yml#/paths/~1scim~1v2~1Groups"
+  /scim/v2/Groups/{groupId}:
+    $ref: "./scim/groups.yml#/paths/~1scim~1v2~1Groups~1{groupId}"
+  /scim/v2/Groups/.search:
+    $ref: "./scim/groups.yml#/paths/~1scim~1v2~1Groups~1.search"
+  /scim/v2/Roles:
+    $ref: "./scim/roles.yml#/paths/~1scim~1v2~1Roles"
+  /scim/v2/Roles/{roleId}:
+    $ref: "./scim/roles.yml#/paths/~1scim~1v2~1Roles~1{roleId}"
 
 tags:
   - name: orgs

--- a/api/scim/common.yml
+++ b/api/scim/common.yml
@@ -1,0 +1,79 @@
+components:
+  params:
+    searchStartIndex:
+      name: startIndex
+      in: query
+      description: The starting index for pagination.
+      required: false
+      schema:
+        type: integer
+        example: 1
+    searchCount:
+      name: count
+      in: query
+      description: The number of resources to retrieve.
+      required: false
+      schema:
+        type: integer
+        example: 10
+    searchFilter:
+      name: filter
+      in: query
+      description: Filter resources based on specific criteria.
+      required: false
+      schema:
+        type: string
+        example: "displayName pr"
+  schemas:
+    postSearch:
+      type: object
+      properties:
+        schemas:
+          type: array
+          items:
+            type: string
+            enum:
+            - "urn:ietf:params:scim:api:messages:2.0:SearchRequest"
+        filter:
+          type: string
+          description: Filter expression for resources.
+          example: 'userName co "john.doe"'
+        sortBy:
+          type: string
+          description: Field to sort by.
+          example: "userName"
+        sortOrder:
+          type: string
+          description: Order of sorting (ascending or descending).
+          example: "ascending"
+        attributes:
+          type: array
+          description: A multi-valued list of strings indicating the names of resource attributes to return in the response.
+          items:
+            type: string
+        excludedAttributes:
+          type: array
+          description: A multi-valued list of strings indicating the names of resource attributes to be removed from the default set of attributes to return.
+          items:
+            type: string
+        startIndex:
+          description: The starting index for pagination.
+          type: integer
+          example: 1
+        count:
+          description: The number of resources to retrieve.
+          type: integer
+          example: 10
+    patchItem:
+      type: object
+      properties:
+        op:
+          type: string
+          description: Operation type (add, replace, remove).
+          example: "replace"
+        path:
+          type: string
+          description: The field to be updated.
+        value:
+          type: string
+          description: New value for the field.

--- a/api/scim/groups.yml
+++ b/api/scim/groups.yml
@@ -1,0 +1,358 @@
+paths:
+  /scim/v2/Groups:
+    get:
+      summary: Retrieve list of groups
+      operationId: getGroups
+      tags:
+        - scim
+      parameters:
+        - $ref: "./common.yml#/components/params/searchStartIndex"
+        - $ref: "./common.yml#/components/params/searchCount"
+        - $ref: "./common.yml#/components/params/searchFilter"
+      responses:
+        '200':
+          description: Successfully retrieved list of groups.
+          content:
+            application/scim+json:
+              schema:
+                $ref: "#/components/schemas/GroupsListResponse"
+        '401':
+          description: Unauthenticated
+        '403':
+          description: Unauthorized
+        '500':
+          description: Internal server error.
+
+    post:
+      summary: Create a new group
+      operationId: createGroup
+      tags:
+        - scim
+      requestBody:
+        description: Data for the group to be created.
+        required: true
+        content:
+          application/scim+json:
+            schema:
+              $ref: '#/components/schemas/GroupInRequest'
+      responses:
+        '201':
+          description: Group created successfully.
+          content:
+            application/scim+json:
+              schema:
+                $ref: '#/components/schemas/GroupInResponse'
+        '400':
+          description: Bad request.
+        '401':
+          description: Unauthenticated
+        '403':
+          description: Unauthorized
+        '409':
+          description: Conflict on resource (like displayName).
+        '500':
+          description: Internal server error.
+
+  /scim/v2/Groups/{groupId}:
+    get:
+      summary: Retrieve group by ID
+      operationId: getGroupById
+      tags:
+        - scim
+      parameters:
+        - $ref: '#/components/params/groupIdPathParam'
+      responses:
+        '200':
+          description: Successfully retrieved group details.
+          content:
+            application/scim+json:
+              schema:
+                $ref: '#/components/schemas/GroupInResponse'
+        '401':
+          description: Unauthenticated
+        '403':
+          description: Unauthorized
+        '404':
+          description: Group not found.
+        '500':
+          description: Internal server error.
+
+    put:
+      summary: Update a group by ID
+      description: ⚠️ This operation overwrites all the group's information. In order to pass only some properties to update, please use [PATCH](#tag/scim/operation/patchGroupById) instead.
+      operationId: updateGroupById
+      tags:
+        - scim
+      parameters:
+        - $ref: '#/components/params/groupIdPathParam'
+      requestBody:
+        description: Updated data for the group.
+        required: true
+        content:
+          application/scim+json:
+            schema:
+              $ref: '#/components/schemas/GroupInRequest'
+      responses:
+        '200':
+          description: Group updated successfully.
+          content:
+            application/scim+json:
+              schema:
+                $ref: '#/components/schemas/GroupInResponse'
+        '401':
+          description: Unauthenticated
+        '403':
+          description: Unauthorized
+        '404':
+          description: Group not found.
+        '409':
+          description: Conflict on resource (like displayName).
+        '500':
+          description: Internal server error.
+
+    patch:
+      summary: Partially update a group by ID
+      operationId: patchGroupById
+      tags:
+        - scim
+      parameters:
+        - $ref: '#/components/params/groupIdPathParam'
+      requestBody:
+        description: Data for the partial update of the group.
+        required: true
+        content:
+          application/scim+json:
+            schema:
+              type: object
+              properties:
+                schemas:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                    - urn:ietf:params:scim:api:messages:2.0:PatchOp
+                Operations:
+                  type: array
+                  items:
+                    allOf:
+                      - $ref: "./common.yml#/components/schemas/patchItem"
+                      - type: object
+                        properties:
+                          path:
+                            example: "members[display eq \"John Doe\"].value"
+                          value:
+                            example: "42"
+      responses:
+        '200':
+          description: Group partially updated successfully.
+          content:
+            application/scim+json:
+              schema:
+                $ref: '#/components/schemas/GroupInResponse'
+        '400':
+          description: Bad request.
+        '401':
+          description: Unauthenticated
+        '403':
+          description: Unauthorized
+        '404':
+          description: Group not found.
+        '409':
+          description: Conflict on resource (like displayName).
+        '500':
+          description: Internal server error.
+
+    delete:
+      summary: Delete a group by ID.
+      description: ⚠️ **This action cannot be undone, please be cautious when using this endpoint** ⚠️
+      operationId: deleteGroupById
+      tags:
+        - scim
+      parameters:
+        - $ref: '#/components/params/groupIdPathParam'
+      responses:
+        '204':
+          description: Group deleted successfully.
+        '401':
+          description: Unauthenticated
+        '403':
+          description: Unauthorized
+        '404':
+          description: Group not found.
+        '500':
+          description: Internal server error.
+  /scim/v2/Groups/.search:
+    post:
+      summary: Search groups
+      operationId: searchGroups
+      tags:
+        - scim
+      requestBody:
+        description: Search criteria.
+        required: true
+        content:
+          application/scim+json:
+            schema:
+              allOf:
+                - $ref: "./common.yml#/components/schemas/postSearch"
+                - type: object
+                  properties:
+                    filter:
+                      example: 'displayName eq "Engineering"'
+                    sortBy:
+                      example: 'displayName'
+                    attributes:
+                      example: ['id', 'displayName']
+                    excludedAttributes:
+                      example: ['members']
+      responses:
+        '200':
+          description: Groups retrieved based on search criteria.
+          content:
+            application/scim+json:
+              schema:
+                type: object
+                properties:
+                  schemas:
+                    type: array
+                    items:
+                      type: string
+                      enum:
+                      - "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+                  totalResults:
+                    type: integer
+                    description: Total number of groups found.
+                  Resources:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/GroupInResponse'
+        '400':
+          description: Bad request.
+        '401':
+          description: Unauthenticated
+        '403':
+          description: Unauthorized
+        '500':
+          description: Internal server error.
+
+components:
+  params:
+    groupIdPathParam:
+      in: path
+      name: groupId
+      schema:
+        type: integer
+      description: A group id
+      required: true
+
+  schemas:
+    Member:
+      type: object
+      properties:
+        value:
+          type: string
+          description: The ID of a member.
+          example: "1"
+        display:
+          type: string
+          description: The display name of a member.
+          example: "John Doe"
+        type:
+          type: string
+          description: The type of member (User or Group).
+          example: "User"
+        $ref:
+          type: string
+          description: The URL to access the member
+          example: "/api/scim/v2/Users/1"
+    MembersInResponse:
+      type: array
+      items:
+        allOf:
+          - type: object
+            required:
+              - value
+              - display
+              - type
+              - $ref
+          - $ref: "#/components/schemas/Member"
+    MembersInRequest:
+      type: array
+      items:
+        allOf:
+          - type: object
+            required:
+              - value
+              - type
+          - $ref: "#/components/schemas/Member"
+    GroupsListResponse:
+      type: object
+      properties:
+        schemas:
+          type: array
+          items:
+            type: string
+            enum:
+            - "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+        totalResults:
+          type: integer
+          description: Total number of groups.
+          example: 1
+        itemsPerPage:
+          type: integer
+          description: Number of groups returned per page.
+          example: 20
+        startIndex:
+          type: integer
+          description: Starting index.
+          example: 1
+        Resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupInResponse'
+
+    GroupInRequest:
+      type: object
+      properties:
+        schemas:
+          type: array
+          items:
+            type: string
+            enum:
+            - "urn:ietf:params:scim:schemas:core:2.0:Group"
+        displayName:
+          type: string
+          description: The display name of the group.
+          example: "Engineering"
+        members:
+          $ref: "#/components/schemas/MembersInRequest"
+
+    GroupInResponse:
+      type: object
+      properties:
+        schemas:
+          type: array
+          items:
+            type: string
+            enum:
+              - urn:ietf:params:scim:schemas:core:2.0:Group
+        meta:
+          type: object
+          properties:
+            resourceType:
+              type: string
+              enum:
+              - "Group"
+            location:
+              type: string
+              example: "/api/scim/v2/Groups/1"
+        id:
+          type: string
+          description: The unique identifier of the group.
+          example: "1"
+        displayName:
+          type: string
+          description: The name of the group.
+          example: "Engineering"
+        members:
+          $ref: "#/components/schemas/MembersInResponse"

--- a/api/scim/roles.yml
+++ b/api/scim/roles.yml
@@ -1,0 +1,298 @@
+paths:
+  /scim/v2/Roles:
+    get:
+      summary: Retrieve list of roles.
+      description: |
+        Roles are system-defined entities giving particular permissions to a given resource (document, workspace or organization).
+        This API returns by default all these roles associated to all the resources.
+        You may use the parameters to filter the results.
+      operationId: getRoles
+      tags:
+        - scim
+      parameters:
+        - $ref: "./common.yml#/components/params/searchStartIndex"
+        - $ref: "./common.yml#/components/params/searchCount"
+        - $ref: "./common.yml#/components/params/searchFilter"
+      responses:
+        '200':
+          description: Successfully retrieved list of roles.
+          content:
+            application/scim+json:
+              schema:
+                $ref: "#/components/schemas/RolesListResponse"
+        '401':
+          description: Unauthenticated
+        '403':
+          description: Unauthorized
+        '500':
+          description: Internal server error.
+
+  /scim/v2/Roles/{roleId}:
+    get:
+      summary: Retrieve role by ID
+      operationId: getRoleById
+      tags:
+        - scim
+      parameters:
+        - $ref: '#/components/params/roleIdPathParam'
+      responses:
+        '200':
+          description: Successfully retrieved role details.
+          content:
+            application/scim+json:
+              schema:
+                $ref: '#/components/schemas/RoleInGetResponse'
+        '401':
+          description: Unauthenticated
+        '403':
+          description: Unauthorized
+        '404':
+          description: Role not found.
+        '500':
+          description: Internal server error.
+    put:
+      summary: Update a role by ID
+      description: |
+        ⚠️ This operation overwrites all the memberships (the "members" property). In order to update part of the membership, please use [PATCH](#tag/scim/operation/patchRoleById) instead.
+        Only the memberships are authorized to be modified through this endpoint, other properties will be ignored.
+      operationId: updateRoleById
+      tags:
+        - scim
+      parameters:
+        - $ref: '#/components/params/roleIdPathParam'
+      requestBody:
+        description: Updated data for the role.
+        required: true
+        content:
+          application/scim+json:
+            schema:
+              $ref: '#/components/schemas/RoleInRequest'
+      responses:
+        '200':
+          description: Role updated successfully.
+          content:
+            application/scim+json:
+              schema:
+                $ref: '#/components/schemas/RoleInResponse'
+        '401':
+          description: Unauthenticated
+        '403':
+          description: Unauthorized
+        '404':
+          description: Role not found.
+        '409':
+          description: Conflict on resource (like displayName).
+        '500':
+          description: Internal server error.
+
+    patch:
+      summary: Partially update a role by ID
+      description: |
+        Only the memberships are authorized to be modified through this endpoint, other properties will be ignored.
+      operationId: patchRoleById
+      tags:
+        - scim
+      parameters:
+        - $ref: '#/components/params/roleIdPathParam'
+      requestBody:
+        description: Data for the partial update of the role.
+        required: true
+        content:
+          application/scim+json:
+            schema:
+              type: object
+              properties:
+                schemas:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                    - urn:ietf:params:scim:api:messages:2.0:PatchOp
+                Operations:
+                  type: array
+                  items:
+                    allOf:
+                      - $ref: "./common.yml#/components/schemas/patchItem"
+                      - type: object
+                        properties:
+                          path:
+                            example: "members[display eq \"John Doe\"].value"
+                          value:
+                            example: "42"
+      responses:
+        '200':
+          description: Role partially updated successfully.
+          content:
+            application/scim+json:
+              schema:
+                $ref: '#/components/schemas/RoleInResponse'
+        '400':
+          description: Bad request.
+        '401':
+          description: Unauthenticated
+        '403':
+          description: Unauthorized
+        '404':
+          description: Role not found.
+        '409':
+          description: Conflict on resource (like displayName).
+        '500':
+          description: Internal server error.
+
+components:
+  params:
+    roleIdPathParam:
+      in: path
+      name: roleId
+      schema:
+        type: integer
+      description: A role id
+      required: true
+
+  schemas:
+    Member:
+      type: object
+      properties:
+        value:
+          type: string
+          description: The ID of a member.
+          example: "1"
+        display:
+          type: string
+          description: The display name of a member.
+          example: "Engineering"
+        type:
+          type: string
+          description: The type of member (User or Group).
+          example: "Group"
+        $ref:
+          type: string
+          description: The URL to access the member
+          example: "/api/scim/v2/Groups/1"
+    MembersInResponse:
+      type: array
+      items:
+        allOf:
+          - type: object
+            required:
+              - value
+              - display
+              - type
+              - $ref
+          - $ref: "#/components/schemas/Member"
+    MembersInRequest:
+      type: array
+      items:
+        allOf:
+          - type: object
+            required:
+              - value
+              - type
+          - $ref: "#/components/schemas/Member"
+    RoleInRequest:
+      type: object
+      properties:
+        schemas:
+          type: array
+          items:
+            type: string
+            enum:
+            - "urn:ietf:params:scim:schemas:Grist:1.0:Role"
+        members:
+          $ref: "#/components/schemas/MembersInRequest"
+    RolesListResponse:
+      type: object
+      properties:
+        schemas:
+          type: array
+          items:
+            type: string
+            enum:
+            - "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+        totalResults:
+          type: integer
+          description: Total number of roles.
+          example: 1
+        itemsPerPage:
+          type: integer
+          description: Number of roles returned per page.
+          example: 20
+        startIndex:
+          type: integer
+          description: Starting index.
+          example: 1
+        Resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/RoleInGetResponse'
+    RoleInGetResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/RoleInResponse'
+        - type: object
+          required:
+            - schemas
+            - id
+            - meta
+            - displayName
+            - members
+          properties:
+            displayName:
+              type: string
+              description: The name of the role.
+              example: "owners"
+        - oneOf:
+          - type: object
+            required:
+              - orgId
+            properties:
+              orgId:
+                type: number
+                description: The ID of the organization that the role applies to
+                example: 1
+          - type: object
+            required:
+              - workspaceId
+            properties:
+              workspaceId:
+                type: number
+                description: The ID of the workspace that the role applies to
+                example: 2
+          - type: object
+            required:
+              - docId
+            properties:
+              docId:
+                type: string
+                description: The ID of the document that the role applies to
+                example: diHs5TB4mq6BQXw5RvBVu4
+    RoleInResponse:
+      type: object
+      properties:
+        schemas:
+          type: array
+          items:
+            type: string
+            enum:
+              - urn:ietf:params:scim:schemas:Grist:1.0:Role
+        meta:
+          type: object
+          properties:
+            resourceType:
+              type: string
+              enum:
+              - "Role"
+            location:
+              type: string
+              example: "/api/scim/v2/Roles/1"
+        id:
+          type: string
+          description: The unique identifier of the role.
+          example: "1"
+        displayName:
+          type: string
+          description: The name of the role.
+          example: "owners"
+        members:
+          $ref: "#/components/schemas/MembersInResponse"
+

--- a/api/scim/users.yml
+++ b/api/scim/users.yml
@@ -6,27 +6,9 @@ paths:
       tags:
         - scim
       parameters:
-        - name: startIndex
-          in: query
-          description: The starting index for pagination.
-          required: false
-          schema:
-            type: integer
-            example: 1
-        - name: count
-          in: query
-          description: The number of users to retrieve.
-          required: false
-          schema:
-            type: integer
-            example: 10
-        - name: filter
-          in: query
-          description: Filter users based on specific criteria.
-          required: false
-          schema:
-            type: string
-            example: "userName pr"
+        - $ref: "./common.yml#/components/params/searchStartIndex"
+        - $ref: "./common.yml#/components/params/searchCount"
+        - $ref: "./common.yml#/components/params/searchFilter"
       responses:
         '200':
           description: Successfully retrieved list of users.
@@ -97,7 +79,7 @@ paths:
 
     put: &put-user
       summary: Update a user by ID
-      description: ⚠️  This operation override all the user's information. In order to pass only some properties to update, please use [PATCH](#tag/scim/operation/patchUserById) instead.
+      description: ⚠️  This operation overwrites all the user's information. In order to pass only some properties to update, please use [PATCH](#tag/scim/operation/patchUserById) instead.
       operationId: updateUserById
       tags:
         - scim
@@ -152,20 +134,14 @@ paths:
                 Operations:
                   type: array
                   items:
-                    type: object
-                    properties:
-                      op:
-                        type: string
-                        description: Operation type (add, replace, remove).
-                        example: "replace"
-                      path:
-                        type: string
-                        description: The field to be updated.
-                        example: "photos[primary eq true].value"
-                      value:
-                        type: string
-                        description: New value for the field.
-                        example: "https://example.com/pics/john-doe.png"
+                    allOf:
+                      - $ref: "./common.yml#/components/schemas/patchItem"
+                      - type: object
+                        properties:
+                          path:
+                            example: "photos[primary eq true].value"
+                          value:
+                            example: "https://example.com/pics/john-doe.png"
       responses:
         '200':
           description: User partially updated successfully.
@@ -187,7 +163,7 @@ paths:
           description: Internal server error.
 
     delete: &delete-user
-      summary: Delete a user by ID. 
+      summary: Delete a user by ID.
       description: ⚠️ **This action cannot be undone, please be cautious when using this endpoint** ⚠️
       operationId: deleteUserById
       tags:
@@ -218,47 +194,18 @@ paths:
         content:
           application/scim+json:
             schema:
-              type: object
-              properties:
-                schemas:
-                  type: array
-                  items:
-                    type: string
-                    enum:
-                    - "urn:ietf:params:scim:api:messages:2.0:SearchRequest"
-                filter:
-                  type: string
-                  description: Filter expression for users.
-                  example: 'userName co "john.doe"'
-                sortBy:
-                  type: string
-                  description: Field to sort by.
-                  example: "userName"
-                sortOrder:
-                  type: string
-                  description: Order of sorting (ascending or descending).
-                  example: "ascending"
-                attributes:
-                  type: array
-                  description: A multi-valued list of strings indicating the names of resource attributes to return in the response.
-                  items:
-                    type: string
-                  example: [ "id", "displayName" ]
-                excludedAttributes:
-                  type: array
-                  description: A multi-valued list of strings indicating the names of resource attributes to be removed from the default set of attributes to return.
-                  items:
-                    type: string
-                  example: [ "locale" ]
-                startIndex:
-                  description: The starting index for pagination.
-                  type: integer
-                  example: 1
-                count:
-                  description: The number of users to retrieve.
-                  type: integer
-                  example: 10
-
+              allOf:
+                - $ref: "./common.yml#/components/schemas/postSearch"
+                - type: object
+                  properties:
+                    filter:
+                      example: 'userName pr'
+                    sortBy:
+                      example: 'userName'
+                    attributes:
+                      example: ['id', 'displayName']
+                    excludedAttributes:
+                      example: ['locale']
       responses:
         '200':
           description: Users retrieved based on search criteria.
@@ -407,7 +354,7 @@ components:
             properties:
               resourceType:
                 type: string
-                enum: 
+                enum:
                 - "User"
               location:
                 type: string

--- a/help/en/docs/install/scim.md
+++ b/help/en/docs/install/scim.md
@@ -6,9 +6,9 @@ SCIM {: .tag-core .tag-ee }
 ====
 
 !!! warning "🚧 Status of SCIM"
-    As of November 2024, the SCIM endpoint is experimental and in active development. Also please note that group management is not supported yet.
+    As of November 2024, the SCIM endpoint is experimental and in active development.
 
-## Use case and difference with SSO systems 
+## Use case and difference with SSO systems
 
 Grist supports authentication via [OIDC](oidc.md) or [SAML](saml.md) to allow users to log in securely. However, when managing large organizations with dynamic user bases, manual user management (creation, updating, and deletion of accounts) can become complex and time-consuming. This is where the System for Cross-domain Identity Management (SCIM) comes in.
 
@@ -33,6 +33,34 @@ For more details on the SCIM standard, refer to the official IETF specifications
 ## The API
 
 The SCIM implementation is documented in the [Grist REST API reference](../api.md#tag/scim).
+
+## The entities
+
+The following SCIM entities can be queried and manipulated through the Grist SCIM API:
+
+- The users through `/Users`.
+
+    These are simply regular users as you can see them in Grist.
+
+- The groups of users (or *teams*) through `/Groups`.
+
+    ⚠️ Please note that this feature is very experimental. Adding a team to a document,
+    workspace, or organization is possible, but as of December 2025, teams/groups added via SCIM
+    are not displayed in the UI (especially in the Users Management popup). However, these teams/groups
+    will still have access as configured. To verify group membership or access, please use the SCIM API
+    or the REST API directly, as changes may not be visible in the UI until future updates resolve this limitation.
+
+- The roles (`owners`, `editors`, `viewers`, `members`, `guests`) through `/Roles`
+
+    The Roles are the ones you see in the Users Management popup: `owners`,
+    `editors`, `viewers`, `guests` and `members`.
+    Each role gives a certain access to a resource: a document, a workspace or
+    an organization (aka *team site*).
+    You can use Roles to grant Users (`/scim/v2/Users`) or
+    Groups (`/scim/v2/Groups`) access to one of these resources.
+
+!!! note "Roles are system-defined"
+    Roles (`owners`, `editors`, `viewers`, `members`, `guests`) are predefined by Grist and cannot be created or deleted through the SCIM API. You can only query roles and modify their memberships (i.e., assign or remove users/groups from roles).
 
 ## Enabling and configuring SCIM
 


### PR DESCRIPTION
## The context

After PR https://github.com/gristlabs/grist-core/pull/1357 has been merged, the support website and the api console lack the documentation of the groups and the roles introduced by this PR.

## How to test

I suggest to take a look at the support website generated or to the apiconsole if you change the URL of this line:
https://github.com/gristlabs/grist-core/blob/6398395d6da5d1db2bf08b6a83e5d7d54d378f4c/app/client/apiconsole.ts#L365

With `http://localhost:3000/grist.yml` when you run `http-server -p 3000 --cors` in the `api/` folder ([http-server can be downloaded through npm](https://www.npmjs.com/package/http-server)).