### PR TITLE
Fix images in <center> tags; fix most anchor links that build warns about

### DIFF
--- a/help/en/docs/FAQ.md
+++ b/help/en/docs/FAQ.md
@@ -26,7 +26,7 @@ team site on a paid plan is associated with its own subscription, and is billed 
 
 2. **Adding account to team site.** You may own or be a member of multiple teams sites. If you have multiple Grist login accounts, you may also add your second account as a team member. While in the team site you own, open the user menu and click on 'Manage Users'.
 
-**Did you know?** 
+**Did you know?**
 
 A single team site can work well for an organization with multiple teams (or subteams). You can use workspaces
 within a team site, and [manage access to them](workspaces.md#managing-access) to create separate
@@ -42,7 +42,7 @@ You can now easily switch between all your accounts, and all your teams, from th
 
 Open the [user menu](glossary.md#user-menu) by clicking on the profile icon in the top-right of Grist, then select 'Profile Settings'.
 
-From here, you can manage the name associated with your account, update Grist's theme to light or dark mode, set a language and create and manage an API key. To learn more about our API, check out [Grist API](rest-api.md#grist-api).
+From here, you can manage the name associated with your account, update Grist's theme to light or dark mode, set a language and create and manage an API key. To learn more about our API, check out [Grist API](rest-api.md).
 
 **Would you like to help translate Grist?**
 
@@ -75,7 +75,7 @@ Documents shared with you from other personal accounts will be shown in your per
 
 You may navigate between your [personal site](teams.md#understanding-personal-sites) and [team sites](teams.md) by clicking in the top-left corner to open a drop-down menu of sites to which you have access.
 
-<center>*![Navigating between sites](images/faq/personal-and-team-site.png)*</center>
+<center markdown>*![Navigating between sites](images/faq/personal-and-team-site.png)*</center>
 
 ### How to manage ownership of my team site?
 
@@ -107,7 +107,7 @@ If you’re transferring team site ownership between two Grist email accounts th
 
 You may edit your site name and subdomain from the billing page. Open the [user menu](glossary.md#user-menu) by clicking on the profile icon in the top-right of Grist, then click on ['Billing Account'](teams.md#billing-account).
 
-<center>*![Public access](images/faq/edit-subdomain.png)*</center>
+<center markdown>*![Public access](images/faq/edit-subdomain.png)*</center>
 
 ---
 
@@ -139,7 +139,7 @@ Non-English characters are supported in column labels, but not column ids, which
 
 To [edit column labels and ids](col-types.md#renaming-columns) separately, open the creator panel and select the column menu. Click the link icon that joins label to id to enable column id editing. While non-English characters are not supported, it is possible to edit the ids into something more clear and friendly to use in formulas. 
 
-<center>*![Editing column labels and id](images/faq/editing-col-label-id.png)*</center>
+<center markdown>*![Editing column labels and id](images/faq/editing-col-label-id.png)*</center>
 
 ### How do I sum the total of a column?
 
@@ -176,7 +176,7 @@ There are many ways to share Grist data with non-team members.
 1. **Guests.** Each document may be shared with 2 guests (non-team members) at no additional cost.
 2. **Link sharing.** In share settings, there is an option to turn on [public access](sharing.md#public-access-and-link-sharing). The public access role can be set to viewer or editor. Anyone with a link can view (or edit) your data. Those views would not count towards your plan's user count. The document is visible to anyone with the link, however, so use caution when working with sensitive data.
 
-<center>*![Public access](images/faq/link-sharing.png)*</center>
+<center markdown>*![Public access](images/faq/link-sharing.png)*</center>
 
 3. **Restricted view-only link sharing.** With view-only link sharing, there is a way to further restrict what people can see by using Grist's access rules to set specific URL parameters called [link keys](access-rules.md#link-keys) that determine which tables, columns, or rows are shown when a specific link is shared. 
 

--- a/help/en/docs/col-types.md
+++ b/help/en/docs/col-types.md
@@ -60,7 +60,7 @@ Learn more about each shortcut option at the links below:
 
 - [Detect Duplicates in...](formula-cheat-sheet.md#finding-duplicates)
 
-- [Date helpers...](dates.md#getting-a-part-of-the-date)
+- [Date helpers...](dates.md#displaying-days-weeks-years-and-intervals)
 
 - [UUID](access-rules.md#link-keys)
 
@@ -225,7 +225,7 @@ The Markdown cell format in Grist supports a subset of markdown, including lists
 bold and italic text, code spans and code blocks, and blockquotes. It does _not_ currently support
 images or custom HTML.
 
-### Hyperlinks (deprecated)
+### Hyperlinks (deprecated) {: #hyperlinks }
 
 When a Text column uses "HyperLink" formatting, values get formatted like so:
 
@@ -266,7 +266,7 @@ The options under NUMBER FORMAT include:
   {: .screenshot-half }
   
 !!! note "Setting Default Currency"
-    You can set a document's default timezone, locale, and currency in [Document Settings](creating-doc.md#document-settings).
+    You can set a document's default timezone, locale, and currency in [Document Settings](document-settings.md).
   
   
 - `,`: Turn on the display of thousands separators.
@@ -311,7 +311,7 @@ format for dates, see the [date and time formatting reference](https://momentjs.
 <span class="screenshot-large">*![columns-format-datetime](images/columns/columns-format-datetime.png)*</span>
 {: .screenshot-half }
 
-If you'd like to set a default timezone for your document, you can do so in [Document Settings](creating-doc.md#document-settings).
+If you'd like to set a default timezone for your document, you can do so in [Document Settings](document-settings.md).
 
 ## Choice columns
 
@@ -401,7 +401,7 @@ while the cell is being edited. You can also use the arrow keys and the
 when hovering your cursor over a choice.
 
 !!! note "Filtering Choice and Choice List columns' dropdown lists"
-    When entering data into a Choice or Choice List column you will see a dropdown list of all available choices. Sometimes it would be useful to filter the dropdown list based on a condition, such as the value in another cell. Writing conditions to filter choice dropdown lists is similar to [filtering reference column's dropdown lists](col-refs.md#filtering-reference-choices-in-dropdown).
+    When entering data into a Choice or Choice List column you will see a dropdown list of all available choices. Sometimes it would be useful to filter the dropdown list based on a condition, such as the value in another cell. Writing conditions to filter choice dropdown lists is similar to [filtering reference column's dropdown lists](col-refs.md#filtering-reference-choices-in-dropdown-lists).
 
 ## Reference columns
 

--- a/help/en/docs/examples/2021-05-reference-columns.md
+++ b/help/en/docs/examples/2021-05-reference-columns.md
@@ -98,7 +98,7 @@ we saw that clicking on a job application would populate a view of milestones re
 application.
 
 Let’s do that now by adding `Milestones` as a widget to the `Job Applications` page. ([Brush up on
-widgets here](../page-widgets.md#page-widgets).) Adding the table as a
+widgets here](../page-widgets.md#widgets).) Adding the table as a
 Card List widget makes the data easier to view. Similarly, you may want to change the `Job
 Applications` table to a Card List widget.
 

--- a/help/en/docs/exports.md
+++ b/help/en/docs/exports.md
@@ -11,7 +11,7 @@ you can export that table as either an XLSX file or a CSV, a common interchange 
 To do this, open your document to the desired table or widget. Then click the three dot menu in the top right of the widget. 
 Select either 'Download as CSV' or 'Download as XLSX'.
 
-<center>![Export Table](images/exports/export-table.png)</center>
+<center markdown>![Export Table](images/exports/export-table.png)</center>
 
 Your browser will then download a file containing a header row
 naming your columns, excluding any hidden columns or filtered-out rows, followed by all the
@@ -23,7 +23,7 @@ If you want to export all of the attachments from a document, click the share ic
 (<span class="grist-icon" style="--icon: var(--icon-Share)"></span>)
 on the top right of the screen and select 'Download attachments...'.
 
-<center>![Download attachments](images/exports/exports-download-attachments.png)</center>
+<center markdown>![Download attachments](images/exports/exports-download-attachments.png)</center>
 
 Select the desired format from the dropdown. `.tar` is recommended, as it can be used to 
 [restore external attachments](exports.md#restoring-external-attachments) in re-uploaded documents.
@@ -37,7 +37,7 @@ If you want to export all tables to Excel format, click the share icon
 (<span class="grist-icon" style="--icon: var(--icon-Share)"></span>)
 on the top right of the screen and select 'Export as...' then 'Microsoft Excel (.xlsx)'.
 
-<center>![Export Document](images/exports/export-xlsx.png)</center>
+<center markdown>![Export Document](images/exports/export-xlsx.png)</center>
 
 Your browser will then download an Excel file, where each table is a separate sheet
 containing all rows, without any filters applied. To use this option you need to have full

--- a/help/en/docs/install/assistant.md
+++ b/help/en/docs/install/assistant.md
@@ -6,11 +6,11 @@ Assistant for self-hosters {: .tag-ee }
 ==============
 
 !!! warning "Note"
-    This documentation refers to the current [Assistant](/assistant), which is only available on the Enterprise edition. You can find the documentation for the legacy AI Formula Assistant [here](ai-assistant-legacy.md).
+    This documentation refers to the current [Assistant](../assistant.md), which is only available on the Enterprise edition. You can find the documentation for the legacy AI Formula Assistant [here](ai-assistant-legacy.md).
 
 ## How to set up the Assistant
 
-You can use the [Assistant](/assistant) in self-hosted Grist with your AI provider of choice or a local model. The Assistant currently only supports chat completion API endpoints such as those provided by OpenAI (e.g. `/v1/chat/completions`), and models that support tool calling and structured output.
+You can use the [Assistant](../assistant.md) in self-hosted Grist with your AI provider of choice or a local model. The Assistant currently only supports chat completion API endpoints such as those provided by OpenAI (e.g. `/v1/chat/completions`), and models that support tool calling and structured output.
 
 To enable the Assistant, specify the completion endpoint to use by setting the `ASSISTANT_CHAT_COMPLETION_ENDPOINT` environment variable as follows:
 

--- a/help/en/docs/install/scim.md
+++ b/help/en/docs/install/scim.md
@@ -32,7 +32,7 @@ For more details on the SCIM standard, refer to the official IETF specifications
 
 ## The API
 
-The SCIM implementation is documented in the [Grist REST API reference](/api/#tag/scim).
+The SCIM implementation is documented in the [Grist REST API reference](../api.md#tag/scim).
 
 ## Enabling and configuring SCIM
 

--- a/help/en/docs/page-widgets.md
+++ b/help/en/docs/page-widgets.md
@@ -17,7 +17,7 @@ In Grist, you organize your document into 'pages'. These are listed in the left-
 *![Renaming Pages Menu](images/rename_pages1.png)*
 {: .screenshot-half }
 
-* **Renaming** the page does not edit data tables' names or widget titles. See [changing widget](page-widgets.md#changing-widget-or-its-data) below to learn how to edit table and widget names.
+* **Renaming** the page does not edit data tables' names or widget titles. See [changing widget](page-widgets.md#changing-a-widget-or-its-data) below to learn how to edit table and widget names.
 * **Duplicating** a page duplicates *views* of data and does not duplicate the data itself.
 * **Removing** a page does not delete data. When removing the last view of data, you will be asked if you want to delete only the view, but not the data itself; or if you want to delete both the page and the underlying data table(s). Learn more about your document's data in the [raw data page](raw-data.md).
 

--- a/help/en/docs/raw-data.md
+++ b/help/en/docs/raw-data.md
@@ -9,13 +9,13 @@ The raw data page is a special page that lists all [data tables](glossary.md#dat
 From your document, navigate to the raw data page by clicking on the 'Raw Data' link in the bottom left of the pages menu.
 
 <span class="screenshot-large">*![Raw Data in Menu](images/raw-data/raw-data-nav.png)*</span>
-{: .screenshot-half } 
+{: .screenshot-half }
 
-Unlike other [pages](page-widgets.md), the layout in the raw data page cannot be customized. From the list of data tables, you can find the data table's name and id, and remove data. Note that removing a data table from this page *will* delete data and remove it from all pages. This is different from other pages where it is possible to remove a view of data and not delete the data itself. 
+Unlike other [pages](page-widgets.md), the layout in the raw data page cannot be customized. From the list of data tables, you can find the data table's name and id, and remove data. Note that removing a data table from this page *will* delete data and remove it from all pages. This is different from other pages where it is possible to remove a view of data and not delete the data itself.
 
 ![Raw Data List](images/raw-data/raw-data-list.png)
 
-Click on a data table to open it. Note that in the creator panel the [widget type](page-widgets.md#page-widgets) cannot be changed. Renaming the widget also renames the data table. Because raw data is intended to show all data, columns cannot be hidden, either. However, columns can be rearranged, deleted, created, and modified. For creators, this view may make it easier to edit data structure, add [formulas](formulas.md), [conditional formatting](conditional-formatting.md), and so on.
+Click on a data table to open it. Note that in the creator panel the [widget type](page-widgets.md#widgets) cannot be changed. Renaming the widget also renames the data table. Because raw data is intended to show all data, columns cannot be hidden, either. However, columns can be rearranged, deleted, created, and modified. For creators, this view may make it easier to edit data structure, add [formulas](formulas.md), [conditional formatting](conditional-formatting.md), and so on.
 
 ![Raw Data View](images/raw-data/raw-data-lightbox.png)
 

--- a/help/en/docs/self-managed.md
+++ b/help/en/docs/self-managed.md
@@ -763,7 +763,7 @@ Follow these steps:
 
 By default, Grist installations do not send detailed information to
 any central service, [except for some version
-information](#how-do-i-control-automatic-checks-for-new-installed-versions).
+information](#how-do-i-control-automatic-version-checks).
 It is useful to permit Grist to send more information, to give Grist
 Labs some limited insight into your usage, through measurements called
 telemetry. This will help guide development, and draw attention to

--- a/help/fr/docs/FAQ.md
+++ b/help/fr/docs/FAQ.md
@@ -71,7 +71,7 @@ Les documents partagés avec vous depuis d'autres comptes personnels seront affi
 
 Vous pouvez naviguer entre votre [espace personnel](teams.md#understanding-personal-sites) et [espaces d'équipe](teams.md) en cliquant dans le coin supérieur gauche pour ouvrir un menu déroulant des sites auxquels vous avez accès.
 
-<center>*![Naviguer entre les sites](images/faq/personal-and-team-site.png)*</center>
+<center markdown>*![Naviguer entre les sites](images/faq/personal-and-team-site.png)*</center>
 
 ### Comment gérer la propriété de mon espace d'équipe ?
 
@@ -103,7 +103,7 @@ Si vous transférez la propriété d'un espace d'équipe entre deux comptes e-ma
 
 Vous pouvez modifier le nom de votre site et le sous-domaine depuis la page de facturation. Ouvrez le [menu utilisateur](glossary.md#user-menu) en cliquant sur l'icône de profil en haut à droite de Grist, puis cliquez sur ['Compte de facturation'](teams.md#billing-account).
 
-<center>*![Accès public](images/faq/edit-subdomain.png)*</center>
+<center markdown>*![Accès public](images/faq/edit-subdomain.png)*</center>
 
 ---
 
@@ -135,7 +135,7 @@ Les caractères non anglais sont pris en charge dans les étiquettes de colonnes
 
 Pour [modifier les étiquettes et les identifiants de colonnes](col-types.md#renaming-columns) séparément, ouvrez le panneau de création et sélectionnez le menu de la colonne. Cliquez sur l'icône de lien qui joint l'étiquette à l'identifiant pour activer la modification de l'identifiant de la colonne. Bien que les caractères non anglais ne soient pas pris en charge, il est possible de modifier les identifiants pour les rendre plus clairs et conviviaux à utiliser dans les formules.
 
-<center>*![Modification des étiquettes et des identifiants de colonnes](images/faq/editing-col-label-id.png)*</center>
+<center markdown>*![Modification des étiquettes et des identifiants de colonnes](images/faq/editing-col-label-id.png)*</center>
 
 ### Comment puis-je additionner le total d'une colonne ?
 
@@ -172,7 +172,7 @@ Il existe de nombreuses façons de partager des données Grist avec des non-memb
 1. **Invités.** Chaque document peut être partagé avec 2 invités (non-membres de l'équipe) sans frais supplémentaires.
 2. **Partage de lien.** Dans les paramètres de partage, il y a une option pour activer [l'accès public](sharing.md#public-access-and-link-sharing). Le rôle d'accès public peut être défini sur visualiseur ou éditeur. Toute personne ayant un lien peut voir (ou modifier) vos données. Ces vues ne seraient pas comptées dans le nombre d'utilisateurs de votre plan. Le document est visible par toute personne ayant le lien, donc faites preuve de prudence lorsque vous travaillez avec des données sensibles.
 
-<center>*![Accès public](images/faq/link-sharing.png)*</center>
+<center markdown>*![Accès public](images/faq/link-sharing.png)*</center>
 
 3. **Partage de lien en lecture seule restreint.** Avec le partage de lien en lecture seule, il est possible de restreindre davantage ce que les gens peuvent voir en utilisant les permissions avancées de Grist pour définir des paramètres d'URL spécifiques appelés [clés de lien](access-rules.md#link-keys) qui déterminent quelles tables, colonnes ou lignes sont affichées lorsqu'un lien spécifique est partagé.
 

--- a/help/fr/docs/exports.md
+++ b/help/fr/docs/exports.md
@@ -11,7 +11,7 @@ vous pouvez exporter cette table soit en fichier XLSX, soit en CSV, un format d'
 Pour ce faire, ouvrez votre document à la table ou à la vue souhaitée. Ensuite, cliquez sur le menu à trois points en haut à droite de la vue. 
 Sélectionnez soit "Télécharger en CSV" soit "Télécharger en XLSX".
 
-<center>![Exporter une Table](images/exports/export-table.png)</center>
+<center markdown>![Exporter une Table](images/exports/export-table.png)</center>
 
 Votre navigateur téléchargera alors un fichier contenant une ligne d'en-tête
 nommant vos colonnes, à l'exclusion de toute colonne masquée ou ligne filtrée, suivie de toutes les
@@ -23,7 +23,7 @@ Si vous souhaitez exporter toutes les tables au format Excel, cliquez sur l'icô
 (<span class="grist-icon" style="--icon: var(--icon-Share)"></span>)
 en haut à droite de l'écran et sélectionnez "Exporter XLSX".
 
-<center>![Exporter un Document](images/exports/export-xlsx.png)</center>
+<center markdown>![Exporter un Document](images/exports/export-xlsx.png)</center>
 
 Votre navigateur téléchargera alors un fichier Excel, où chaque table est une feuille distincte
 contenant toutes les lignes, sans aucun filtre appliqué. Pour utiliser cette option, vous devez avoir un accès complet


### PR DESCRIPTION
- `<center>` tag now needs to be `<center markdown>` to process image markup inside.
- Also fixed various anchor links in /en/ docs.