### PR TITLE
build REST API page from grist.yml every time

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -21,7 +21,7 @@ jobs:
         run: git fetch origin gh-pages
 
       - name: Building the documentation
-        run: python3 ./docs.py build-all
+        run: ./build-doc.sh
 
       - name: Publish live
         run: |

--- a/build-doc.sh
+++ b/build-doc.sh
@@ -9,3 +9,4 @@ if [ -e env ]; then
 fi
 
 python3 ./docs.py build-all
+./api/build.sh


### PR DESCRIPTION
Updating the API is a bit of a chore since it is maintained in api/grist.yml but a script needs to run to produce content from that. This is an experiment to add the needed step, and see if netlify and github-pages workflows panic have trouble or not. Once done, the API page should probably be removed from version control. We didn't do this historically since it was confusing for people who didn't know where it came from and how to make it.

Motivation for change is so we don't have to ask people to do this https://github.com/gristlabs/grist-help/pull/593#issuecomment-3761160928 or review the resulting code.