### PR TITLE
turn off helpscout workflow

### DIFF
--- a/.github/workflows/push-to-helpscout.yml
+++ b/.github/workflows/push-to-helpscout.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - hscout
   pull_request:
+    branches:
+      - hscout
 jobs:
   push-to-helpscout:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The helpscout workflow has rusted and there are doubts about its utility. This restricts the workflow to a special branch until it can either be repaired or fully removed.