### PR TITLE
mobile sidebar menu: add the parent category name in heading

### DIFF
--- a/help/en/docs/css/theme.css
+++ b/help/en/docs/css/theme.css
@@ -182,6 +182,17 @@ but make sure the borders have WCAG-compliant contrast ratio */
   .md-nav__title .md-nav__button.md-logo svg {
     height: 2rem;
   }
+  .md-nav--primary .g-nav-back-title {
+    position: absolute;
+    top: .6rem;
+    left: 2.3rem;
+    font-size: .7rem;
+    line-height: 1.2rem;
+    font-weight: 400;
+    right: 1rem;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
 }
 @media screen and (min-width: 76.25em) {
   /* make sidebar a bit wider so that the section names are on one line */

--- a/overrides/partials/nav-item.html
+++ b/overrides/partials/nav-item.html
@@ -131,6 +131,11 @@
         <nav class="md-nav" data-md-level="{{ level }}" aria-labelledby="{{ path }}_label" aria-expanded="{{ nav_item.active | tojson }}">
           <label class="md-nav__title" for="{{ path }}">
             <span class="md-nav__icon md-icon"></span>
+            {# CHANGE / addition: show the parent's section heading next to the back button #}
+            <span class="g-nav-back-title">
+              {{ parent.title if parent and parent.title else config.site_name }}
+            </span>
+            {# end CHANGE #}
             {{ nav_item.title }}
           </label>
           <ul class="md-nav__list" data-md-scrollfix>


### PR DESCRIPTION
this helps better understanding where we are when opening the sidebar

Fixes #616.

What do you think @Spoffy @dsagal?


https://github.com/user-attachments/assets/120b2a13-d1fc-4dd7-9dd0-292cfe115b6f

