### PR TITLE
the marketplace README is moving

### DIFF
--- a/help/en/docs/install/aws-marketplace-transition.md
+++ b/help/en/docs/install/aws-marketplace-transition.md
@@ -10,9 +10,8 @@ It is possible to copy your Grist documents to Builder Edition.
 
 1. Take note of the `EMAIL` variable under `~/grist/gristParameters`.
 2. Start [a Grist Builder Edition instance](grist-builder-edition.md).
-3. Follow [the instructions to run the bootstrap
-   script](https://github.com/gristlabs/grist-pack/tree/main/dist#quickstart),
-   using the value of `EMAIL` for the `DEFAULT_EMAIL` value. See
+3. Follow the instructions to run the bootstrap script,
+   using the value of `EMAIL` you noted earlier. See
    [here](../self-managed.md#what-is-the-administrative-account) for
    more details pertaining to this variable.
    

--- a/help/en/docs/install/grist-builder-edition.md
+++ b/help/en/docs/install/grist-builder-edition.md
@@ -20,7 +20,7 @@ The Grist instance must be managed by SSH or equivalent console access. Details 
 * Linux: [https://www.ssh.com/academy/ssh/command](https://www.ssh.com/academy/ssh/command)
 * macOS: [https://www.servermania.com/kb/articles/ssh-mac](https://www.servermania.com/kb/articles/ssh-mac)
 
-Once you log in, follow the instructions displayed in the console. Further technical details regarding configuration can be found in [the README supplied with the installation](https://github.com/gristlabs/grist-pack/blob/main/dist/README.md).
+Once you log in, follow the instructions displayed in the console. Further technical details regarding configuration can be found in the README supplied with the installation.
 
 If you need some help with the initial configuration, read on below for some specific instructions for each cloud provider.
 

--- a/help/fr/docs/install/aws-marketplace-transition.md
+++ b/help/fr/docs/install/aws-marketplace-transition.md
@@ -10,8 +10,8 @@ Il est possible de copier vos documents Grist vers Builder Edition.
 
 1. Notez la variable `EMAIL` sous `~/grist/gristParameters`.
 2. Démarrez [une instance Grist Builder Edition](grist-builder-edition.md).
-3. Suivez [les instructions pour exécuter le script bootstrap](https://github.com/gristlabs/grist-pack/tree/main/dist#quickstart),
-   en utilisant la valeur de `EMAIL` pour la valeur `DEFAULT_EMAIL`. Voir
+3. Suivez les instructions pour exécuter le script bootstrap,
+   en utilisant la valeur de `EMAIL` que vous avez notée précédemment. Voir
    [ici](../self-managed.md#quest-ce-que-le-compte-administratif) pour
    plus de détails concernant cette variable.
    

--- a/help/fr/docs/install/grist-builder-edition.md
+++ b/help/fr/docs/install/grist-builder-edition.md
@@ -20,7 +20,7 @@ L'instance Grist doit être gérée par SSH ou un accès console équivalent. Le
 * Linux : [https://www.ssh.com/academy/ssh/command](https://www.ssh.com/academy/ssh/command)
 * macOS : [https://www.servermania.com/kb/articles/ssh-mac](https://www.servermania.com/kb/articles/ssh-mac)
 
-Une fois connecté, suivez les instructions affichées dans la console. D'autres détails techniques concernant la configuration peuvent être trouvés dans [le README fourni avec l'installation](https://github.com/gristlabs/grist-pack/blob/main/dist/README.md).
+Une fois connecté, suivez les instructions affichées dans la console. D'autres détails techniques concernant la configuration peuvent être trouvés dans le README fourni avec l'installation.
 
 Si vous avez besoin d'aide avec la configuration initiale, lisez ci-dessous pour des instructions spécifiques pour chaque fournisseur de cloud.
 


### PR DESCRIPTION
It used to be the marketplace README was available online also, and help docs linked to it there as duplication, but it is moving. This removes the links that will become stale. The instructions themselves remain accurate.