### PR TITLE
Fix some little typos and tidy up a few old links

### DIFF
--- a/help/en/docs/access-rules.md
+++ b/help/en/docs/access-rules.md
@@ -213,7 +213,7 @@ not copied: the new copy will not have it on.
 
 ## Restrict access to columns
 
-We can restrict a collaborator's access to columns.  In our eample, we might
+We can restrict a collaborator's access to columns.  In our example, we might
 wish to give a delivery specialist more limited access to
 the `Orders` table.  Perhaps they don't need to see an **Email** column,
 or a **Piece** column with details of what is in the parcel.
@@ -256,7 +256,7 @@ document from the colleague's perspective.
 In our example, we could select Kiwi, and the
 document reopens, with a large banner stating that we are viewing it
 as Kiwi.  The **Piece** and **Email** columns are missing,
-and the `Financials` table is surpressed:
+and the `Financials` table is suppressed:
 
 ![Access rules](images/access-rules/access-rules-view-as-kiwi.png)
 
@@ -291,7 +291,7 @@ column to match against, **Email**.
 
 Save that. Now we can update our rules to be more general.  We find with
 autocomplete that we have a new `user.Team` variable available in
-condtions.  It makes columns from the `Team` available, such as `user.Team.Role`.
+conditions.  It makes columns from the `Team` available, such as `user.Team.Role`.
 Now we can check if the user has a particular role, and apply the permissions
 that go with that:
 

--- a/help/en/docs/authorship.md
+++ b/help/en/docs/authorship.md
@@ -47,8 +47,8 @@ pick and choose which columns, when updated, will trigger the formula.
 
 ![an Updated-By column](images/formulas/formulas-updated-by-setup.png)
 
-Here is an example the the new column at work - when `Cotton Candy v Candy Floss`
-is updated,a user name appears for that record:
+Here is an example of the new column at work - when `Cotton Candy v Candy Floss`
+is updated, a user name appears for that record:
 
 ![an Updated-By column](images/formulas/formulas-updated-by-autofill.png)
 

--- a/help/en/docs/connected-apps.md
+++ b/help/en/docs/connected-apps.md
@@ -40,7 +40,7 @@ Choosing 'Selected resources' opens a picker:
 
 ![Resource picker](images/connected-apps/resource-picker.png)
 
-Authorize only the apps you intend by reviewing the app info, especially the shown
+Only authorize apps you trust, after reviewing the app info, especially the shown
 URL. It's best to follow the principle of least privilege to grant access only to the resources
 the app needs. You can come back later to change that selection.
 
@@ -76,7 +76,7 @@ This is also where you can change which documents a connected app can access, or
 | Tied to | Your account | A specific app and grant |
 | Can revoke individually? | No (one key per account) | Yes (revoke any one app) |
 
-For any integration that supports it, we recommend using the connected app rather than an API key –
+For any integration that supports it, we recommend using the connected app rather than an API key --
 for better security, convenience, and visibility. Each connection is scoped to specific documents,
 is visible in the list of authorized apps, and can be revoked individually.
 

--- a/help/en/docs/enter-data.md
+++ b/help/en/docs/enter-data.md
@@ -8,7 +8,7 @@ A spreadsheet-like grid is a great way to see data. In Grist, this is the view
 offered by the default page widget called "Table".
 
 As in a spreadsheet, you can use the mouse or arrow keys to move around the
-cells of a table. To start entering data into a selecte cell, either start
+cells of a table. To start entering data into a selected cell, either start
 typing, hit <code class="keys">*Enter*</code>, or double-click the cell.
 
 ## Editing cells

--- a/help/en/docs/examples/2021-03-leads.md
+++ b/help/en/docs/examples/2021-03-leads.md
@@ -5,7 +5,7 @@ title: Lead list
 # A lead table, with assignments
 
 Access rules let you control how a shared document is used, and maintain
-a separation of roles and responsibilities.  In this example, we suppose an entrepeneur
+a separation of roles and responsibilities.  In this example, we suppose an entrepreneur
 is using Grist as an ad-hoc lead tracker for sales and potential advisors:
 
 [![Lead table](../examples/images/2021-03-leads/leads-table.png)](https://public.getgrist.com/3NsoHE2mWtEp/Lead-list/m/fork)
@@ -21,7 +21,7 @@ which you can see yourself [by visiting the example](https://public.getgrist.com
 There are three blocks of rules.  First, the rule for the Advisors table:
 
   * This restricts all access to the Advisors table to the owner.  We assume the
-    document is owned by the entrepeneur, and shared with anyone else as an editor.
+    document is owned by the entrepreneur, and shared with anyone else as an editor.
 
 Next, there are rules for the Leads table:
 

--- a/help/en/docs/examples/2023-07-proposals-contracts.md
+++ b/help/en/docs/examples/2023-07-proposals-contracts.md
@@ -194,7 +194,7 @@ In the last portion of the formula, we can specify variables that pull from othe
     The **Customer Address** column can be deleted from the `Projects` table completely. This data is already stored in the `Customers` table and our **Customer Name** column is a reference column pointing to this table. We can use this reference column to pull any other information from the `Customers` table to include in our proposal. If you choose to delete **Customer Address** from the `Projects` table, update the last section of formula to the following:
 
     ```
-    template.format_map(Find_data(
+    template.format_map(Find_Data(
       Customer_Name = $Customer_Name.Name,
       Customer_Address = $Customer_Name.Address.replace('\n', '<br>'),
     ))

--- a/help/en/docs/functions.md
+++ b/help/en/docs/functions.md
@@ -1161,7 +1161,7 @@ using the NASD standard calendar. For use in non-financial settings, option `-1`
 likely the best choice.
 
 See <https://en.wikipedia.org/wiki/360-day_calendar> for explanation of
-the US 30/360 and European 30/360 methods. See <http://www.dwheeler.com/yearfrac/> for analysis of
+the US 30/360 and European 30/360 methods. See <https://web.archive.org/web/20210118174252/https://dwheeler.com/yearfrac/> for analysis of
 Excel's particular implementation.
 
 Basis `-1` is similar to `1`, but differs from Excel when dates span both leap and non-leap years.

--- a/help/en/docs/install/assistant.md
+++ b/help/en/docs/install/assistant.md
@@ -53,7 +53,7 @@ You may then specify the model to use by setting `ASSISTANT_MODEL`:
 ASSISTANT_MODEL=anthropic/claude-sonnet-4.5
 ```
 
-The Assistant is know to work with the following OpenRouter models:
+The Assistant is known to work with the following OpenRouter models:
 
  * `openai/gpt-4o-2024-08-06` (last tested: 10-02-2025)
  * `anthropic/claude-sonnet-4.5` (last tested: 10-02-2025)

--- a/help/en/docs/install/aws-marketplace-legacy.md
+++ b/help/en/docs/install/aws-marketplace-legacy.md
@@ -47,7 +47,7 @@ Once the above has been configured, you should be able to log in with your Googl
 
 * Assigning a public DNS name to the Grist EC2 instance is allowed.
 * The VPC can be accessed from the internet (allowing internet gateway and routing tables to handle traffic).
-* A security group connection from ports 22 (SSH for configuration), 80 (HTTP connection) and 433 (HTTPS connection) is allowed.
+* A security group connection from ports 22 (SSH for configuration), 80 (HTTP connection) and 443 (HTTPS connection) is allowed.
 
 ## Updating `grist-omnibus`
 

--- a/help/en/docs/install/aws-marketplace-transition.md
+++ b/help/en/docs/install/aws-marketplace-transition.md
@@ -10,7 +10,7 @@ It is possible to copy your Grist documents to Builder Edition.
 
 1. Take note of the `EMAIL` variable under `~/grist/gristParameters`.
 2. Start [a Grist Builder Edition instance](grist-builder-edition.md).
-3. Follow the instructions to run the bootstrap script,
+3. Follow the bootstrap instructions displayed in the console,
    using the value of `EMAIL` you noted earlier. See
    [here](../self-managed.md#what-is-the-administrative-account) for
    more details pertaining to this variable.

--- a/help/en/docs/install/grist-builder-edition.md
+++ b/help/en/docs/install/grist-builder-edition.md
@@ -36,7 +36,7 @@ If you don’t want to connect via SSH, AWS provides the option to connect from 
 
 #### Azure
 
-When deploying the virtual machine you may be asked to use SSH keys or password, as well as the default user to log in as. The default user is named `azureuser`, and you can login as `azureuser@[azure-vm-public-ip]`.
+When deploying the virtual machine you may be asked to use SSH keys or password, as well as the default user to log in as. The default user is named `azureuser`, and you can log in as `azureuser@[azure-vm-public-ip]`.
 
 **Note:** If you choose to use default method of SSH keys, you need to use the `*.pem` file you received when Azure generated key pairs.
 

--- a/help/en/docs/integrators.md
+++ b/help/en/docs/integrators.md
@@ -10,7 +10,6 @@ include:
 - [Zapier](https://zapier.com/apps/grist/integrations)
 - [Integrately](https://integrately.com/integrations/grist)
 - [Pabbly Connect](https://www.pabbly.com/connect/integrations/grist/)
-- [KonnectzIT](https://plan.konnectzit.com/feedback/grist-integration)
 - [n8n](https://n8n.io/integrations/n8n-nodes-base.grist)
 - [Make](https://www.make.com/en/integrations/grist?utm_source=grist-app&utm_medium=partner&utm_campaign=grist-app-partner-program)
 

--- a/help/en/docs/mcp.md
+++ b/help/en/docs/mcp.md
@@ -157,7 +157,7 @@ and the underlying scope name is shown in parentheses.
 * **Read documents** (`doc:read`): list and query tables, records, columns, and attachments.
 * **Modify records** (`doc:write`): add, update, and remove rows.
 * **Modify schema** (`doc.schema:write`): add, rename, or remove tables and columns.
-* **Download documents** (`doc:download`): export full documents as CSV or Excel. Not used by any
+* **Download documents** (`doc:download`): download documents in full. Not used by any
   MCP tool currently.
 * **Manage webhooks** (`doc:webhooks`): create, read, update, and delete document webhooks.
 

--- a/help/en/docs/mcp.md
+++ b/help/en/docs/mcp.md
@@ -3,9 +3,6 @@ title: "Grist MCP server"
 description: "Connect Claude and other MCP-aware tools to Grist team sites and documents."
 ---
 
-!!! warning "Pre-release document"
-    This is a draft document and the features described here are not enabled yet.
-
 Model Context Protocol (MCP) is an open standard that lets AI assistants access external data. Any
 MCP-aware tool (such as Claude or ChatGPT) can use Grist's MCP server to work with your team sites
 and documents: list and search tables, read and query rows, add or update rows, and create new

--- a/help/en/docs/oauth-apps.md
+++ b/help/en/docs/oauth-apps.md
@@ -155,7 +155,7 @@ later, you always have the option to regenerate the secret from the app configur
 Regenerating the secret will break existing integrations that still use the old secret,
 including any background tasks relying on refresh tokens.
 
-If the app is no longer used, you may use 'Delete app' button to delete it.
+If the app is no longer used, you may use the 'Delete app' button to delete it.
 
 ## Resource selections
 

--- a/help/en/docs/references-lookups.md
+++ b/help/en/docs/references-lookups.md
@@ -168,7 +168,7 @@ Here, `$Registrants` is a reference list. Our Great Outdoors Expo has 4 registra
 
 <span class="screenshot-large">*![reference-list-registrants](images/references-lookups/reference-list-registrants.png)*</span>
 
-With a reference list, dot-notation returns a list of all the selected field;
+With a reference list, dot-notation returns a list of all the selected fields;
 
 <span class="screenshot-large">*![registrants-balance](images/references-lookups/registrants-balance.png)*</span>
 

--- a/help/en/docs/self-managed.md
+++ b/help/en/docs/self-managed.md
@@ -681,7 +681,7 @@ client:
   ...
 ```
 
-As per [MinIO specs](https://min.io/docs/minio/linux/developers/go/API.html#:~:text=Default%20value%20is%20us-east,us-east-1).), the default bucket region is `us-east-1`. This default region can be overwritten using the `GRIST_DOCS_MINIO_BUCKET_REGION` flag.
+As per [MinIO specs](https://docs.min.io/community/minio-object-store/developers/go/API.html), the default bucket region is `us-east-1`. This default region can be overwritten using the `GRIST_DOCS_MINIO_BUCKET_REGION` flag.
 
 For details, and other options, see [Cloud Storage](install/cloud-storage.md).
 

--- a/help/en/docs/self-managed.md
+++ b/help/en/docs/self-managed.md
@@ -681,7 +681,7 @@ client:
   ...
 ```
 
-As per [MinIO specs](https://docs.min.io/community/minio-object-store/developers/go/API.html), the default bucket region is `us-east-1`. This default region can be overwritten using the `GRIST_DOCS_MINIO_BUCKET_REGION` flag.
+As per [MinIO specs](https://github.com/minio/minio-go/blob/master/docs/API.md#makebucketctx-contextcontext-bucketname-string-opts-makebucketoptions-error), the default bucket region is `us-east-1`. This default region can be overwritten using the `GRIST_DOCS_MINIO_BUCKET_REGION` flag.
 
 For details, and other options, see [Cloud Storage](install/cloud-storage.md).
 

--- a/help/en/docs/widget-form.md
+++ b/help/en/docs/widget-form.md
@@ -38,7 +38,7 @@ To add additional form elements, click the + icon at the bottom of the form. Fro
 
 *![widget-form-elements-side](images/widget-form/widget-form-elements-side.png)*
 
-You can remove any element from the form by hovering over the object and clicking the trash icon to delete. You can hide any uneccessary fields from the form by hovering over the object and clicking the x icon.
+You can remove any element from the form by hovering over the object and clicking the trash icon to delete. You can hide any unnecessary fields from the form by hovering over the object and clicking the x icon.
 
 *![widget-form-delete](images/widget-form/widget-form-delete.png)*
 

--- a/help/fr/docs/integrators.md
+++ b/help/fr/docs/integrators.md
@@ -9,7 +9,6 @@ Grist peut être connecté à des milliers d'autres services via des intégrateu
 - [Zapier](https://zapier.com/apps/grist/integrations)
 - [Integrately](https://integrately.com/integrations/grist)
 - [Pabbly Connect](https://www.pabbly.com/connect/integrations/grist/)
-- [KonnectzIT](https://plan.konnectzit.com/feedback/grist-integration)
 - [n8n](https://n8n.io/integrations/n8n-nodes-base.grist)
 - [Make](https://www.make.com/en/integrations/grist?utm_source=grist-app&utm_medium=partner&utm_campaign=grist-app-partner-program)
 


### PR DESCRIPTION
A small cleanup pass through the help pages. Fixes a few spelling slips, a couple of links that had stopped working, an example that used slightly the wrong name, and a port number with a typo.