### PR TITLE
Bring the useful 'connect to Claude' link to the top of Grist MCP page, and make it more visible

### DIFF
--- a/help/en/docs/mcp.md
+++ b/help/en/docs/mcp.md
@@ -8,6 +8,10 @@ MCP-aware tool (such as Claude or ChatGPT) can use Grist's MCP server to work wi
 and documents: list and search tables, read and query rows, add or update rows, and create new
 documents and tables.
 
+!!! note "Add a Grist connector to Claude"
+    [Connect Grist to Claude](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Grist&connectorUrl=https%3A%2F%2Fdocs.getgrist.com%2Fapi%2Fmcp){:target="\_blank"}
+    {: .grist-button}
+
 For Grist's built-in AI assistant, see [AI Assistant](assistant.md).
 
 ## Setting up the MCP server

--- a/help/en/docs/mcp.md
+++ b/help/en/docs/mcp.md
@@ -8,7 +8,7 @@ MCP-aware tool (such as Claude or ChatGPT) can use Grist's MCP server to work wi
 and documents: list and search tables, read and query rows, add or update rows, and create new
 documents and tables.
 
-!!! note "Add a Grist connector to Claude"
+!!! note "Want to add a Grist connector to Claude?"
     [Connect Grist to Claude](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Grist&connectorUrl=https%3A%2F%2Fdocs.getgrist.com%2Fapi%2Fmcp){:target="\_blank"}
     {: .grist-button}
 


### PR DESCRIPTION
Now that we are linking to this page from a banner inviting users to connect Grist to Claude and linking to https://support.getgrist.com/mcp/, let's make sure that page make is clear and visible what to click to do that.

The page gets immediately technical after the first paragraph, and the link to Claude is buried. This PR adds brings a button with this link to near the top of the page.