### PR TITLE
Free team sites are limited to 10 team members

### DIFF
--- a/help/en/docs/limits.md
+++ b/help/en/docs/limits.md
@@ -19,13 +19,15 @@ Older free plans had a limit of ten documents. Learn more about [legacy limits](
 
 ## Number of collaborators
 
-For team sites on all plans, there is no limit on the number of team members that may be added to the site.  For paid plans, the number of team members determines the price. See our [pricing page](https://www.getgrist.com/pricing) for details.
+Free team sites are limited to 10 team members. On paid plans, there is no limit on the number of team members that may be added to the site, and the number of team members determines the price. See our [pricing page](https://www.getgrist.com/pricing) for details.
+
+A free team site that has reached the limit cannot add more team members. To add someone new, remove an existing member first, or upgrade the site. Sites that are over the limit will become read-only until they are within the limit again.
 
 Team members added to your team site may inherit access to workspaces or documents
 within that organization. Learn more about [team
 sharing](team-sharing.md).
 
-On both personal and team sites, each document may be shared with up to 2 free guests who do not affect the plan price even on paid plans.
+On both personal and team sites, each document may be shared with up to 2 free guests who do not affect the plan price even on paid plans. Guests are not team members, and do not count toward the team member limit.
 
 ## Number of tables per document
 

--- a/help/en/docs/newsletters/2022-08.md
+++ b/help/en/docs/newsletters/2022-08.md
@@ -143,6 +143,11 @@ title: 2022/08
 
 Grist is most powerful when used collaboratively. That’s why we’re now offering free team sites for your whole team. Unlimited team members + unlimited documents, for documents under 5,000 rows.  Free team sites are fully featured, too.
 
+!!! note "Update, August 2026"
+    Free team sites are now limited to 10 team members. Documents remain
+    unlimited, and guests do not count toward the limit. See
+    [Limits](../limits.md#number-of-collaborators) for details.
+
 [CREATE FREE TEAM SITE](https://docs.getgrist.com/billing/create-team?planType=teamFree){:target="\_blank"}
 {: .grist-button}
 


### PR DESCRIPTION
The limits page said there was no limit on team members for team sites on any plan. Free team sites are now capped at 10, so state the cap, what happens at it and over it, and say that guests do not count toward it, since they are capped separately per document.

The August 2022 newsletter announced free team sites with "unlimited team members", and is still served in the archive. Note the limit there too, as a dated note rather than an edit to the announcement, so what was said at the time stays readable.